### PR TITLE
2008 runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .flatpak-builder
+build-dir
 jamovi
 repo

--- a/base-deps-sources.json
+++ b/base-deps-sources.json
@@ -1,374 +1,404 @@
 [
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/R6_2.4.1.tar.gz",
-        "sha512": "bf165edf15f4fb3a4ad94b80bcf96f255b6889649b40c7f27af10841a55d81d02f8a42707fc08a5bcadfa94d77d67f4617739a75b3e7d99ba57bb9100dde98b0",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/R6_2.5.0.tar.gz",
+        "sha512": "09cfd4c5bde6ff46ec64622e81e24e944f325e720f6a65d476faca045505954e66a6a0efe9abeb9c88646c8071cda1c0267e325a342f00ee1933694d4d3a22c7",
         "dest": "000_R6.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RColorBrewer_1.1-2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RColorBrewer_1.1-2.tar.gz",
         "sha512": "29eeecae274c57f2af3366d072fb6a61a1e0be64aae9393e10c7e92c3b98473b60b7042b532c49e0ce2f53e6dce1a728ddd6937bbc64cedcb3664a429c3e54da",
         "dest": "001_RColorBrewer.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/base64enc_0.1-3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/base64enc_0.1-3.tar.gz",
         "sha512": "e486a4dd8ec8ec72285440c016e9e73d2e7f73dc864472ce7204bab15eb00f2cb26cf29c20dfb1e3087372aaaed961344dc84f691576c1ff64a58dc342341287",
         "dest": "002_base64enc.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/bitops_1.0-6.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/bitops_1.0-6.tar.gz",
         "sha512": "0761883d2b0ff4cbb7908e4c1999f045a323c3094e0351e26e8bc9481c3922e60099fb7c3f2abf1e4b45b8a120e074d9d59678559fb4ab7d0ead59d07c6f2a2a",
         "dest": "003_bitops.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/curl_4.3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/brio_1.1.1.tar.gz",
+        "sha512": "81b3ffcb9fbb891341e19a899452300abe4e1e8139fbf3a45e905cfe8a5b02f108025b7e4d0699ceaa31e7e7f01daf97b02b3457f0036f0d34a743c0c3edba06",
+        "dest": "004_brio.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/cpp11_0.2.7.tar.gz",
+        "sha512": "8210a57823c00f4b5c6739f53d653e9d3fa422bcf771dcc3857c0bc12a602fd09079da308490af7c42fe561e734e94cfa327fe6e232b60769f06322487228c1e",
+        "dest": "005_cpp11.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/curl_4.3.tar.gz",
         "sha512": "666a1fd209587c4fb051d8c60c57f7c2e365216a7dd8d7f0d520c211c8f9790235ff77b7a1799d00380e755f9d520000ae7d2ad74394b8acae441458a5c73022",
-        "dest": "004_curl.Rpkg"
+        "dest": "006_curl.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/fansi_0.4.1.tar.gz",
-        "sha512": "01289228240f245f13d4f65f368bec183d779018038f0e4f5b4aa6379676f5eda10d32b9c8a5c373d1cfcadec449b6d3efe05f0e09161430263e08be7da58ffc",
-        "dest": "005_fansi.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/fansi_0.4.2.tar.gz",
+        "sha512": "5b6327e96e0febdb557fcad2a1ba7b91b229ab8d8fb22ff30ae24bd7850dee0b8bcdd66215df365873ed52e0d13736f7ad9219cc71de15ef25c6526fe84b3ce9",
+        "dest": "007_fansi.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/farver_2.0.3.tar.gz",
-        "sha512": "edcd68aad32ad79e27e12539ec8221495a28895e73e7d65149df5367757003b58e19fec4ebb3f5e839702e954f119d98d3e7dfd0f86a1b251a408e79c8ab3723",
-        "dest": "006_farver.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/farver_2.1.0.tar.gz",
+        "sha512": "a89c77a971e831d2b203a011539f5e077d953432156eaff588e8b0cb57536dfaace1d98bd656b9b48eccddb2b1d03dc395e01ae670bde1b769b905bc17eb4129",
+        "dest": "008_farver.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/highr_0.8.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/highr_0.8.tar.gz",
         "sha512": "3ca3bf64457fdb2f4b0122568dac969a33cc1cdeba437d29417c5bea4e8ed4b0ac43d6cf5ad1a4a75719beafc09dcbd31a6b57fd22142b096ce809c5d4c04ab5",
-        "dest": "007_highr.Rpkg"
+        "dest": "009_highr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/labeling_0.3.tar.gz",
-        "sha512": "158b7c2836b86257c513dcbe48abf1ec95ae26e9a3d9e62218704c1924996c58a2f53c853e462ffa3e4d36fbd40400fad6ea28949b3b4c432036f3330711a252",
-        "dest": "008_labeling.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/magrittr_2.0.1.tar.gz",
+        "sha512": "aa27f64ba09494a5afbe0263ec379c4a73110de45f43c6265437192c01c33a0df6dce98bd0ace021b2f380be84c040c7177b00c396842b3415d137e9e01896d2",
+        "dest": "010_magrittr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/magrittr_1.5.tar.gz",
-        "sha512": "d1e66bab279a08f85405fedee0efea0dc4af058e76d8c0151c620825e01a8cf766bf89eaf24a64c67cadbad05c18f780006837ae0e9ded32c2637ed4df984279",
-        "dest": "009_magrittr.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/praise_1.0.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/praise_1.0.0.tar.gz",
         "sha512": "6405e733884e95b165ed285e1a9f6470b76d96abdf3516292bdbacd562667ccc747d78b4abe96d7d512aeb10dde8c6db06d04cbe3e774bbcdb0fc529365bb0b8",
-        "dest": "010_praise.Rpkg"
+        "dest": "011_praise.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/prettyunits_1.1.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/prettyunits_1.1.1.tar.gz",
         "sha512": "563feed049b4d6afda31ff162348a2d4467c49e3273c21937b049a7c4f47181a8bc278fa0b02acce014aefc98f9cddfdf8d65aa2960f63fb66dd1606d708c545",
-        "dest": "011_prettyunits.Rpkg"
+        "dest": "012_prettyunits.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rlang_0.4.7.tar.gz",
-        "sha512": "5854acad351414e0686ebcecda356a24d5263ba329eef1f766b76b4e3a377305437901b41e8188c61db993f0f865eca3949470abe7b4f67b1991d14d82cce397",
-        "dest": "012_rlang.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rprojroot_2.0.2.tar.gz",
+        "sha512": "36f9bcf1435709eea2325e2a0f681782083ae158eaca485af5fb9871c9a3429e8a3a94c4dae1741905d37d8e9538d35d6588fa3e901ef60601de344282497629",
+        "dest": "013_rprojroot.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rstudioapi_0.11.tar.gz",
-        "sha512": "90867658947935621ba7ebfeab07f88b62ab606a2221e868b9b8eaeb93e098fdc432d26e73a012e3f722ba353238010c60ae8db02ba4a998b973f5a3c02741aa",
-        "dest": "013_rstudioapi.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rstudioapi_0.13.tar.gz",
+        "sha512": "608ad60d2b63e4e2c75a33431dd9a075b52d5ec3c8f7cff72e795a519d764a4e7abb7c949f61d3168183c33cc4ad0ed3f358f822fc20feb98d3cde7e92cee92c",
+        "dest": "014_rstudioapi.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/systemfonts_0.2.3.tar.gz",
-        "sha512": "65f8f186b2fb70c7a5e29b86263d50daffd45c1188725db55e6773bca75e61d5b7892111040a1fb41dcda9cd37ad87b08a67bb8d5708b555148ba7eedf51a759",
-        "dest": "014_systemfonts.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/utf8_1.1.4.tar.gz",
-        "sha512": "c45308500417e820285edaba54d5e6f3f2ab599dc388457a85cff0112b454ff09a9e18710762a93fc21239d84440ab844a1a7b134af6111a3cf0e3fa25ed95eb",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/utf8_1.2.1.tar.gz",
+        "sha512": "c91b1000366c44cea0956100cb0c5681466b9f4fd4511c8b4ebf6fb5d14bd71a49b1e4cb082a776af49de05e51c3deb0ba688a9bd740e5e722d41dd9b1eab282",
         "dest": "015_utf8.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/viridisLite_0.3.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/viridisLite_0.3.0.tar.gz",
         "sha512": "116b7a60fef5814e2c1f63d38f473168b11f869f8be888486e19727655a5297717a9b8f54dd123605ae6f02730aa95dc65f1e812bd20c7479a6a8b52e1ab6abf",
         "dest": "016_viridisLite.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/yaml_2.2.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/yaml_2.2.1.tar.gz",
         "sha512": "4a6054aba1355e1e658e5c8c56e2fe991ce650cc091c54d7041b094588eb2269a067a4b23e4030eb357f7a5a73638db10d0865a925bae660e0728098f73f66c1",
         "dest": "017_yaml.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RCurl_1.98-1.2.tar.gz",
-        "sha512": "08fb3939c18944ef35b76ee30b0e13d5b30f568d20616b45fc1a1b231f1cf77b44ee09369c5a8f020fd3ad53fbe15a4b3ad68d2a7325d56345b5f52c043623d0",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RCurl_1.98-1.3.tar.gz",
+        "sha512": "26db97aefbe17fa58406d950af06814055f43b84c1924f600e4cc5c59882b058ff56c058917e3f70e86d0d260ac20c3b241bcd234f1b101e1619783a7acf2a04",
         "dest": "018_RCurl.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/Rcpp_1.0.5.tar.gz",
-        "sha512": "dfca51e0ac14a7c24113568fafec290f2c1e9484709220b5537707af8451179686baf80e397ce548f7c24142d7864c224bd41835e7f61bc5295878755abe21ca",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Rcpp_1.0.6.tar.gz",
+        "sha512": "eab225cfdd838e316824fe224e9822c01d09287251b89f3a83f03b5be294f6f3376f2cd2518f78a7bff57426247b62108dc7c60b89d78443172826fa24bf14cc",
         "dest": "019_Rcpp.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/assertthat_0.2.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/assertthat_0.2.1.tar.gz",
         "sha512": "e8dbcb9b7c638f7133dea70443debbf739d35df1eb5ef19d5ae2ad7e9669f06184af43477ee061e15d253b3fa32ec203dbe28a4585c2027d4e567c2eb2195337",
         "dest": "020_assertthat.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/backports_1.1.8.tar.gz",
-        "sha512": "fa5ecd027dbce93b3b3958fc4dca3a37e7af3bfc1bfb00da1d818c4e1a349b2fffbe53fccf02a4f85b545a2a5dad7829b324cdca2353754d09b52e049bc1636d",
-        "dest": "021_backports.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/colorspace_2.0-0.tar.gz",
+        "sha512": "9f0b2c89afa5b9ca31004d6f2f11d51c298754ab4a1fba6e9637974f4bb38920b45221681fdc1eb206a8540c590d0036a9addeb1cbe2a868d10be80ada419610",
+        "dest": "021_colorspace.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/colorspace_1.4-1.tar.gz",
-        "sha512": "70b9c30a29ab55963cb1424cf3d13ec5d57cf632864dd33e7f2a8b3d8898defb94c2353352f4fa70ecc467bad6543693e6f5ed31a589b107c7b6960614533ad4",
-        "dest": "022_colorspace.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/crayon_1.4.1.tar.gz",
+        "sha512": "cb449c04c8ecf8e78d91a8deb0d0ebe2407e4c608f0d001448985aca0cf81f1a5371ea0e1c96cb598d947db4b3f5ad484c7b4f6457ff06cd9bfce3cbb45b483c",
+        "dest": "022_crayon.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/crayon_1.3.4.tar.gz",
-        "sha512": "201e5e9b02cf10c4f098d07e0c982d3a4d8ee6c18dce666a4b74734c7b1d853af97d1aa4991470ddb89e4f3b5baa321f9fd4eabe1034f52b5ac10d051aa2eb18",
-        "dest": "023_crayon.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/digest_0.6.27.tar.gz",
+        "sha512": "e97f2232d2bbebb2f5daf8f240a37ac9fae6d7ab57fc96c693fdca5436d8b9d1984ada5bd6f11c9683ae9096eda87db02d292f2d111b06af6f878f34bc46c639",
+        "dest": "023_digest.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/digest_0.6.25.tar.gz",
-        "sha512": "5fb3683a3d20740aee0c98bdd52e60ebad3e7c7ca8db770d360aebf138b81f1623b70cdb382b2b32c5b7b59dbeef529cc2a75a7c5421c8be90c08c5a46bb1bc1",
-        "dest": "024_digest.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ellipsis_0.3.1.tar.gz",
-        "sha512": "a8752e3cc52e13ec9503eeb19956ab604a6d1588b892501a14493697dc829507b5cdd64a361de4469c37420c0ba85cde44ca7a24c5e016b9dfc817d5666fe328",
-        "dest": "025_ellipsis.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/evaluate_0.14.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/evaluate_0.14.tar.gz",
         "sha512": "3a74a7fd9ce7d933a3070954c54ab36ca39b0fe5b90227ebaa7a35bff7642ce438240034f43f40f47e7d80788489ad6018fc5901dc7266df773fe380e16105a5",
-        "dest": "026_evaluate.Rpkg"
+        "dest": "024_evaluate.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/glue_1.4.1.tar.gz",
-        "sha512": "b57153757814b47ca85b2f20ec8c64f2dd6647a3b463b4d31b371e78654c0a20f5fb5551c5918d10bc801e588e8c01c38662286922a9f053cf5c5b18982eea37",
-        "dest": "027_glue.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/glue_1.4.2.tar.gz",
+        "sha512": "d4c43c95fedf881be2fbe0e406a282e9af30b741533b653cb3c84ead8952e971d94cb4b6a98df07551b17726630b426e6178296e1c146e6cf04e9a7bd6d0562c",
+        "dest": "025_glue.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/gtable_0.3.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gtable_0.3.0.tar.gz",
         "sha512": "20fa86874a286f5b49ca428040113cb94272df966dd8e0403648ecc76672d8680239fc8030ea803cf65c5baa3acf1698b068b7c51163fa7f27acc31242befc52",
-        "dest": "028_gtable.Rpkg"
+        "dest": "026_gtable.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/jsonlite_1.7.0.tar.gz",
-        "sha512": "d148e98624bddb373aae2043fb0618d29dc92109198cdeade53bb20694441ccb0903d994ed5b5b66338e6e434c97750790c973e3a94a32dc8854c6edb62b2591",
-        "dest": "029_jsonlite.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/isoband_0.2.4.tar.gz",
+        "sha512": "8d83afd3b5cecc33721e52b9241fd7cb1fde6b8d9e35da6ca8afbda63e603f71d4208fdb22777d6a992bf26eb66680d85d44ad267cdf89a2a6007afbe2ee8cde",
+        "dest": "027_isoband.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/mime_0.9.tar.gz",
-        "sha512": "d93dade67f8145600630b6af8a91ec378ce605c8153340fe1761612854e93a21d20b6b364e255d348eaaba1cfe14a50f33138a487356cf5e77ef21c79f7ece0b",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/jsonlite_1.7.2.tar.gz",
+        "sha512": "7156958ea4666440161c6d91a7bc988b674b06299aa3acae97cdedbe597353fa38ffcd276934cf7d8080ce560e7265db3ddd90c7a437cc44cc30756640023ed1",
+        "dest": "028_jsonlite.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/labeling_0.4.2.tar.gz",
+        "sha512": "e61b544dd22e35e9a55123045c9bd4fe6105619e6413462f89a64cbf626749d52465b857cf4142c4f1502e37ad775949825a29c4864846ec84de8ab49edadbee",
+        "dest": "029_labeling.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mime_0.10.tar.gz",
+        "sha512": "6c5401b11e7a480744ef21db51a3afd49d4a5dda1440ee2f8aba95e90b3ebdc596bfeec993b72b953bd99cdae37b16f031e4f6e54e74ded7d78c810eb29812cd",
         "dest": "030_mime.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pkgconfig_2.0.3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pkgconfig_2.0.3.tar.gz",
         "sha512": "bfc5d0bf707ed6d13348d9c01f9470428fc2f020e72d0122a3356548bbebe4d8bd2b288dabd2ec90069935622b2df842f57a8fe9b67b51c01e7c7029921fcfb9",
         "dest": "031_pkgconfig.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ps_1.3.4.tar.gz",
-        "sha512": "9e44ac51638909531040ba1c9a53ffb8250dd239514034c9048eae19d010043531f147c8db8dd45220de971031827bdfc691be5a18e69457212fb51fd50d3dd5",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ps_1.6.0.tar.gz",
+        "sha512": "c5110e86ea72a3c1aff4d93fbcb630b00d9b59e49271530327dfa8f1f7f88b9caab909b76d1638f77518292bec438412961375035e156b3ceebe6fed381bae45",
         "dest": "032_ps.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ragg_0.3.1.tar.gz",
-        "sha512": "c7aef1147739069a5d72458011d0ec1ed469117616c47d305089661deed5c39650f18b86b9a91574f45ea1b087f1e211dd214b7f3174e5c7589a8707f8df13e3",
-        "dest": "033_ragg.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/remotes_2.2.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/remotes_2.2.0.tar.gz",
         "sha512": "b0b4e880901870f990c69a46d08590162cbc9c94fe8875eee5b18d263fc9950b5c739e304e7f399d4febb979f1d55b6268a7588f93df91b060048fd6bd7fabe4",
-        "dest": "034_remotes.Rpkg"
+        "dest": "033_remotes.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/stringi_1.4.6.tar.gz",
-        "sha512": "1844757f6485ea13272e3aa67eea98c451547e1cc518f2f56a734e04c0b06ff2b38c7950e1d8486cbdf18e6828f40765e18de85ad7dc8fc74dc3a204af653d95",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rlang_0.4.10.tar.gz",
+        "sha512": "f251217a448c484941d34edf5cb0964ab34f552c303ad3793084c03e57e4b6024c32a810644d3b2ba9d3b989b850b676ed5a89376d14507bbd2365feb4c7db2d",
+        "dest": "034_rlang.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/stringi_1.5.3.tar.gz",
+        "sha512": "9a473ad0bc00c24815ede79221f8e645957936ec40a698e8784fccdde27ce4eac3603628f9ddd120bf8510157247570c7f65e7a15307ba5b6ca4b73a59c93f3d",
         "dest": "035_stringi.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/withr_2.2.0.tar.gz",
-        "sha512": "f56ab518c6457fd58cdcc9e9a5f8ed8f8e6e4ff74299c7d95bd0b9f76725b08c0fc19ec9238f824fda9e577360f608bdcc410ddda7fb673d2a38de0d3f3c3b22",
-        "dest": "036_withr.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/systemfonts_1.0.1.tar.gz",
+        "sha512": "513f6cc0d57c8ed9258c76f75862b8ab2f95ddb16fe342f37da509d527da66a90da19657329987d77de07d63481e431bdbd72c3f32e379472c9a4a3033e95366",
+        "dest": "036_systemfonts.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/xfun_0.16.tar.gz",
-        "sha512": "4e99f2504dcf35b659f169a12ea550c2c428c856c33e75bf5a627ec642b7127f5526701f67a18a14351bf4958e37ce118458a5dceaeee98f086d4c8bb06e4af2",
-        "dest": "037_xfun.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/withr_2.4.1.tar.gz",
+        "sha512": "e115675b7cc2eaae9148bc5bdf4e711c4bca3c34c78c4bdef2f520ba06240a217c831ca590c5b2479bd799b2c4e32ccb956632ed0b961117d3e26465d7b54f1a",
+        "dest": "037_withr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RInside_0.2.16.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/xfun_0.22.tar.gz",
+        "sha512": "b767aad26072250474935353ee79d5197f08fe6d719d2328646b46922c08acb86b296b8306d85bb7645ddf53a776c0252190cf806361c4e396b21f00112f034e",
+        "dest": "038_xfun.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RInside_0.2.16.tar.gz",
         "sha512": "367430d2243864532688aea17cabca45e9dfcaa357b5a19dfd8fa3c8878d0c38e55815feba00c27541e1a908507766bbe5a4b87274734fa1b66581da254fc215",
-        "dest": "038_RInside.Rpkg"
+        "dest": "039_RInside.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RProtoBuf_0.4.17.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RProtoBuf_0.4.17.tar.gz",
         "sha512": "4112eb8e4776c966f1482cecfb2076561d0c9adbf3d60d39ab7d2a56ba1d180633aea3536ae7b29f2de9ff81e3bfb4b1f700a1eb977e58431b96f8fa75a7af24",
-        "dest": "039_RProtoBuf.Rpkg"
+        "dest": "040_RProtoBuf.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/cli_2.0.2.tar.gz",
-        "sha512": "c5a398a35bfbc43b618b97477ef97785c674c1aad03fcbf20786f1eab057cd5f21da430ffa69161d14a331b2e538d8dc75b6a3a2699db799b1441dce31d3761e",
-        "dest": "040_cli.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/cli_2.3.1.tar.gz",
+        "sha512": "37cbe182ae855f06b75dcad589b9bb35d44b2ea3acb8ffdbcb2a0b704168d8a72c72daaa5d2ca98f2cd0dc2f2def7de43760552edaafa1e21929e313f93247c8",
+        "dest": "041_cli.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/htmltools_0.5.0.tar.gz",
-        "sha512": "edc3efa47e3803141fb84f3165d93f03600a6583ac0a00a4ee6bc26ab38f561766c655dabb1f04933fcb01a1f474fb6963cd96558647295b0854da588f2be34a",
-        "dest": "041_htmltools.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/desc_1.3.0.tar.gz",
+        "sha512": "a478a5589732971c6255accbd12ed88ab030f3ee39cdc690f6c537dbaeb3937c1185146c2035435f103c323faf3fa1e593246c90d5d776fd78d29f40352351b4",
+        "dest": "042_desc.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/lifecycle_0.2.0.tar.gz",
-        "sha512": "f939b65a7eaaff543ffaf7284b07d551d2f851a1975a17116d7cdd3561dcf2e60d79561912f6e007a3d60c8a4e78727e74a96532f2555a5d6cc365a6f1e1dde5",
-        "dest": "042_lifecycle.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/diffobj_0.3.4.tar.gz",
+        "sha512": "b0c8e846615f3cd85092a806f99526d26235ca3b35e7c99d489dd112525ef7a2e955cecdc8dfeee5e3fabe8aa77212b2d5eeec28a4021a2a44f76f76038d5994",
+        "dest": "043_diffobj.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/markdown_1.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ellipsis_0.3.1.tar.gz",
+        "sha512": "a8752e3cc52e13ec9503eeb19956ab604a6d1588b892501a14493697dc829507b5cdd64a361de4469c37420c0ba85cde44ca7a24c5e016b9dfc817d5666fe328",
+        "dest": "044_ellipsis.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/htmltools_0.5.1.1.tar.gz",
+        "sha512": "45414e7d71a1d554f89086fbac9938c1cfd299b4480ee678abd86571af84b53acfa021bdd5d2c40194f4acf1163787e2b7539ebe1d1abf7eea57297cca7888b8",
+        "dest": "045_htmltools.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lifecycle_1.0.0.tar.gz",
+        "sha512": "603e1889c41b970a10956aff5b547111bd0166de7c6721419d2ea1667ff36202803faa9a0913710993d15e4713227ae8d9801ab26b0f2e54b06d44838de495a4",
+        "dest": "046_lifecycle.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/markdown_1.1.tar.gz",
         "sha512": "d53da9b7d184154b866e85cad33f1ba836656bca4007486190c1767b7a79f003b86f34ee66c7349c96372c63c5b6762ea00dd5efb731d9b5e9f2aebddeb9b7da",
-        "dest": "043_markdown.Rpkg"
+        "dest": "047_markdown.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/munsell_0.5.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/munsell_0.5.0.tar.gz",
         "sha512": "12a66c2406bf5aecec52a504549e7beeaff67fb67aab9950c24e9e6300b458cf541c818630814433229c1b406a2830a32dc21e10cabcdb4429245d85ba96f8de",
-        "dest": "044_munsell.Rpkg"
+        "dest": "048_munsell.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/processx_3.4.3.tar.gz",
-        "sha512": "aab502de864ab3b3f0ca7bb8b3a5c21bd54e97db85ce024b1e4daab8e48752b87b686a91aa32de6781b59c1a74aaf5aeff36ec3a24be438a5a56df80af68d5a1",
-        "dest": "045_processx.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/processx_3.5.0.tar.gz",
+        "sha512": "8ed38e9a7ae14038ab55dbd7c2ac774b2bc30f0d341a1f8f0e9f7ec47fce4c2f01d41aa1f9f13aa29c58cd147f382a225dbb883fc85bc02102e1a8084b13e806",
+        "dest": "049_processx.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rprojroot_1.3-2.tar.gz",
-        "sha512": "7ea312a39ccf297a83155c849b0399459eb767f869fb327a238258e0f7a69b545c29e005dd33fdc1c1895116554ad0c3efbcc098ca1979610887ce67d8a8ea4b",
-        "dest": "046_rprojroot.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/stringr_1.4.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/stringr_1.4.0.tar.gz",
         "sha512": "c72f150037a5ff55d9d067aef254a37a81cdaab8177b85cc88ba60610e1cfc0d04f0246666ba1a6e2d435e86fcb8cc589d872e24daac65c8faab7c71909b0a99",
-        "dest": "047_stringr.Rpkg"
+        "dest": "050_stringr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tinytex_0.25.tar.gz",
-        "sha512": "b5961503a03d7cb6f55699a5e7a6448dd66601082a3148541489a866ac9f84bf70e98d70e309a0f338696e0e3ad4dc3e805b2442b789d6435d9404219ddf2033",
-        "dest": "048_tinytex.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/textshaping_0.3.3.tar.gz",
+        "sha512": "c8995bab746dcfbe955cc7c60b68437241a5bfc6a73868f7d75286d56b894fef28bc1d3a79e4797ef269f0bf0d89f1da0c7147b19318736e59dd226137c4aec4",
+        "dest": "051_textshaping.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/vctrs_0.3.2.tar.gz",
-        "sha512": "fc9fa39cf0c5eb096c29baa8d62c285eb362a93fecfcc8fd7211fbbf2de9e5324514710c6efa36d2b6238672175fc7026f5494cc4d19da9450ae8638f00846d8",
-        "dest": "049_vctrs.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tinytex_0.31.tar.gz",
+        "sha512": "a9123c6a33c4d360c00ae1f9aed19b4869bee18e49ad95441f7ea543d7f10744eca1c7f271b00c5c6d1bdbb85463439e4e1a75ba5767a1e8bf2843e7e9eb3cee",
+        "dest": "052_tinytex.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/callr_3.4.3.tar.gz",
-        "sha512": "04ef68084b9fb2721566d51d0ca3cbf89ddb78d65e769ba1ed9b337097dd87b7640f7e8e06bc2e6cdf121aba1e7f9567bcaf7277d886686a079f1630713f16df",
-        "dest": "050_callr.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/callr_3.6.0.tar.gz",
+        "sha512": "eb25cbf50f6e1a39295c39d88e01cd76ad6fca977977ff4d8db85517d8b56d452ee475ec7e139e7ac75dea3dd05646b5fb22d8993af96e18a4fb7c89f075c05d",
+        "dest": "053_callr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/desc_1.2.0.tar.gz",
-        "sha512": "c0ef146faa28aa9b7f2ca20a5711d6e1f5553b8d4292d3e8d877e37ca78ebf720a8eca8fd3a5dc4ddef339fd28c639bb4e20813b8f2be4f5666897385eb456fc",
-        "dest": "051_desc.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/knitr_1.31.tar.gz",
+        "sha512": "b02c769df3a5958bfe934a538a2d8d8a95faed69ca9bc9dd2588e88cb6c29d5ab76a1503bce0bbcd11dd7aba20874226e25004023d4ea7b718651ddae588557a",
+        "dest": "054_knitr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/knitr_1.29.tar.gz",
-        "sha512": "6b9df9878fef673649c032a164b0a9ed42981d69fd3a003fd89302d028ac107356a083b5c59522b7dfe34771e46dd86558344a23b1d34e8b40b65687a8f0770c",
-        "dest": "052_knitr.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ragg_1.1.2.tar.gz",
+        "sha512": "4f7433b9b98df5a53e87d1890aa40a221b1b91bdd551d9b43710dfb7a69062a78cc6e4ccc32fe673333e6055c26d2d97723dac8952accaf00ded732172e3ece1",
+        "dest": "055_ragg.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pillar_1.4.6.tar.gz",
-        "sha512": "3ded62d352ad5298acffa198995d30578a8524f86b4f1571b81d78fdaf47131d51fcbeb468370e5a7b0abff7033d4a99ba8cc83794fa574fda7a0c52a7762395",
-        "dest": "053_pillar.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/scales_1.1.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/scales_1.1.1.tar.gz",
         "sha512": "5e0eb71d0122e94577243747a8bf12dffcfab7a466bee7ae8bcd92cc17e188fdb617d0ab7a60a4728a2a27b5f8953684b2eb43bee22973de2ff708f8c8ad855d",
-        "dest": "054_scales.Rpkg"
+        "dest": "056_scales.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pkgbuild_1.1.0.tar.gz",
-        "sha512": "657215fc46855288432dd407972cc7678d85d2e7f9a135901eae6cfa3c09189feacdd29fd54108949bcddc58f58b688a313afdd788256d0e21023c20ee455651",
-        "dest": "055_pkgbuild.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/vctrs_0.3.7.tar.gz",
+        "sha512": "6474585edab12d58ca9abe612e71148d9d6d3f7f32250645e0ffc463fc3a9007ccbfe8c7b7a6a752dab7f382490a15889cbe0e433e2a4d51ec659c54b37681f7",
+        "dest": "057_vctrs.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rmarkdown_2.3.tar.gz",
-        "sha512": "aa02e4650b8cd51e84554655c742fb9ab73bffc3107ad222750fc7f75130b18b0d255e5d3db3eff9ff998f2c9797b9522a5d05e06ec15141d4287eda54d3b8ff",
-        "dest": "056_rmarkdown.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pillar_1.5.1.tar.gz",
+        "sha512": "a7dbcfa659506a10b03859d48ee3cabe1fea1874c82d0cecdf246f4a1de5aa4d24949ea5998d52fa172f296870960f572000c3f9784d1a073622f6f5d497befe",
+        "dest": "058_pillar.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tibble_3.0.3.tar.gz",
-        "sha512": "3ee7303478680fe111d43162b92ca20552094083e6cb49fe7cb135e6078de4847ac16c5e6d93d3c77bed3a0ab42a53ec46e0bcb934f24d0a5a66f7eabac0e5b3",
-        "dest": "057_tibble.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pkgbuild_1.2.0.tar.gz",
+        "sha512": "f94f924ec6cca5cd61a9bbffdbc09ba3a7c48cd3300223900f8d9a5d4bd24d288be61e4d03a50f72a7c06297d01e276b1164279cd6c6cb0add9ebed20fec456c",
+        "dest": "059_pkgbuild.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pkgload_1.1.0.tar.gz",
-        "sha512": "0e1fd0954ed303a168d35d99e2cbe2a07f53afa6c16f463aacacecc1364944a3532c505deff0667caa4773204de60c0d9a286d060c7c07b56eb8ae2dff5dc8ee",
-        "dest": "058_pkgload.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rmarkdown_2.7.tar.gz",
+        "sha512": "df970286a1ca24b5d10d06d4743b7487314e63ec115a60b15aaefbc9b39f5e942d6ac1b3d1beda7718ea53ec26c4c8e9549ef323a8de5ff1c05d34ab3da1ee41",
+        "dest": "060_rmarkdown.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/testthat_2.3.2.tar.gz",
-        "sha512": "6b104174887792bd02a5d5b851be91b7ade88f80e690c79e9b272bae9e4b06d684b8718d0dee8266dc14e5d1c9d730822ca2d5e00d67ead6dfd5011d990afe56",
-        "dest": "059_testthat.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pkgload_1.2.0.tar.gz",
+        "sha512": "437e1239b0c9b1222c04078f676b1a99b6872784200e74355181837d32deb6849cba23fae87fa106a55a487757c7ab876e581d3ea951c663af429afe7c6d327b",
+        "dest": "061_pkgload.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/isoband_0.2.2.tar.gz",
-        "sha512": "59779445e2ea202f98db088166a6eefcfc20e17821b87d418b8b9ef8d2aa4323fc7c17acf0798fd666bfb96d57bd74436bb457dab8fbf737df9da8da9fa5e2ca",
-        "dest": "060_isoband.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tibble_3.1.0.tar.gz",
+        "sha512": "13c695f671e958569fd3fe452e898c7ffe461a15235c06a549e65e393c5c205a6bfe948219f0b4c3e5d33db7f59d4da65bb09b44fa377f00d285d4bb10d83c38",
+        "dest": "062_tibble.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ggplot2_3.3.2.tar.gz",
-        "sha512": "05d288029a59df3a222fccb4c7b57fbd8ed5ab54028a05e0239a4b18e132c5a0c4d487afac2e93a9901c9eb7b58685368c94ad10a77b951c20322502c074601b",
-        "dest": "061_ggplot2.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ggplot2_3.3.3.tar.gz",
+        "sha512": "6234c2b606bda80b770927975b52c92f9eb7126dcb36889c1d58159c9c2312ff8469a1dd123065c10f77c1f83731285d9a5fdb6d31a1e595169021ece76d717d",
+        "dest": "063_ggplot2.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rematch2_2.1.2.tar.gz",
+        "sha512": "1267df1cfc4def1de163cec121728da2ea7ee66c035aecba1857b4ff77b858e0f9aadb34eedeef97a4ea2716a20f4b87941b7b12b2a921371796c5f80d8769bd",
+        "dest": "064_rematch2.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/waldo_0.2.5.tar.gz",
+        "sha512": "b94540663ece80b62fb423b4016ad7e5a82dd6a6905a1f7a237d0c795fc0823dbb3eeb03db32885ead1d9d6d5e03ac1b90427e7f38556730207d3bf745159131",
+        "dest": "065_waldo.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/testthat_3.0.2.tar.gz",
+        "sha512": "b6ce23dc72a7568722524435aae850831e8605edd22cc11aa6724cbdc830198ce8365d4bf5ebdcfbf739a7776ee80c069e0681b3e2f1d21cfc1bacfe201a5791",
+        "dest": "066_testthat.Rpkg"
     }
 ]

--- a/env.conf
+++ b/env.conf
@@ -11,4 +11,4 @@ JAMOVI_SERVER_CMD=/usr/bin/python3 -u -m jamovi.server 0 --debug --stdin-slave
 JAMOVI_VERSION_PATH=../lib/jamovi/version
 JAMOVI_ICON_PATH=/app/share/app-info/icons/flatpak/128x128/org.jamovi.jamovi.png
 
-JAMOVI_R_VERSION=4.0.2
+JAMOVI_R_VERSION=4.0.5

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "4afde9d0dffd88ce3be5fca9af637cc01e586545"
+        "commit": "1b0e48fc90f2177c8dabef21680239ba69607562"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "85ba7173fe927fe81e4f3b0a41a61f377da08839"
+        "commit": "eb9d54ed4629c473ed5dae1a8a9e84b6542a9e7c"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "5eeff25bf653f808978516a915dfc5e42dc4465f"
+        "commit": "d2e4335810293b8b26b179b690aac4b3bf60f61e"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "fd50546b996972dd46fe5c75d9a62db7ce3e6a87"
+        "commit": "5eeff25bf653f808978516a915dfc5e42dc4465f"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "732f3316f1ba75019472528da3f0dfd2dfaa7350"
+        "commit": "fd50546b996972dd46fe5c75d9a62db7ce3e6a87"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "1b0e48fc90f2177c8dabef21680239ba69607562"
+        "commit": "732f3316f1ba75019472528da3f0dfd2dfaa7350"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "530b89467193ee014b366fcbc3358fb050419f0b"
+        "commit": "0c512c99eceed22a5e220672633a7ec33e4687bc"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "d2e4335810293b8b26b179b690aac4b3bf60f61e"
+        "commit": "2ccd3e44b0d3cd3eec4b22a11752cb8629c840cb"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "eb9d54ed4629c473ed5dae1a8a9e84b6542a9e7c"
+        "commit": "4afde9d0dffd88ce3be5fca9af637cc01e586545"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "2ccd3e44b0d3cd3eec4b22a11752cb8629c840cb"
+        "commit": "062f2ffd93a4d0b5a65b66eccaa28d8e8ac73413"
     }
 ]

--- a/jamovi-source.json
+++ b/jamovi-source.json
@@ -2,6 +2,6 @@
     {
         "type": "git",
         "url": "https://github.com/jamovi/jamovi.git",
-        "commit": "062f2ffd93a4d0b5a65b66eccaa28d8e8ac73413"
+        "commit": "530b89467193ee014b366fcbc3358fb050419f0b"
     }
 ]

--- a/jmv-deps-sources.json
+++ b/jmv-deps-sources.json
@@ -1,764 +1,692 @@
 [
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/BH_1.72.0-3.tar.gz",
-        "sha512": "a2f85fec45329372fb6e9626a2d150c2ea6da899bb2f74c4bafde07e4eaae5df05d95903e2697dcb9e02731164efcfd2322940e14cb8f8fded2f8f3926d5abdd",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/BH_1.75.0-0.tar.gz",
+        "sha512": "03521484256e870d92f8e003b53b2c9f3ea28522c2b30a2465262cfec38becaf7c4ad5f4c72c11903e2189c6440850a81d2fd37c05708d284ee099d998759d77",
         "dest": "000_BH.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/GPArotation_2014.11-1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/GPArotation_2014.11-1.tar.gz",
         "sha512": "98e7506d4e7900a64273b1ad22da07a03990733ae5127c88e46ac5a01792bf3628c8147416a63d3a06237434c429853dcb87a8f65d50bcb7f449c294409dac5b",
         "dest": "001_GPArotation.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RcppParallel_5.0.2.tar.gz",
-        "sha512": "c3d0a2e0fae8e590763e00f8bb70d578b36f6ee099971ef8a147a901bedf9979df430a2e2b4c91030e256802c51cdc627d6b18eabe6d45682150b6be8f9b9465",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RcppParallel_5.0.3.tar.gz",
+        "sha512": "75594ca9d4e71aca37d736177f5c8732cfcd7d1ad6cdf7d99b27d1405088171d2e4bf0c0f9cc54180ce2c8376817fe9f5ef7825569fb684ac420a1b0f3dcba71",
         "dest": "002_RcppParallel.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ca_0.71.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/backports_1.2.1.tar.gz",
+        "sha512": "ec0813fa1a7d99a4848ffe3cd8a44453931df7a321505f6689f1211465ef86847b1359d657406a6086b2ca113ae4d1f136c945e43467d0ed303ecf96fb5e436b",
+        "dest": "003_backports.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ca_0.71.1.tar.gz",
         "sha512": "65dcc058150f4990854c0059cd812dc1561e9b79195481b56a621005e8cb55d8afaf8cdeabf7d2142043e50f2f8352d1609c9493bee0b86d71cb06c875e16067",
-        "dest": "003_ca.Rpkg"
+        "dest": "004_ca.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/carData_3.0-4.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/carData_3.0-4.tar.gz",
         "sha512": "071108df88a0d76ae10f9a0c01801222e6899c82ad8e42c3832ae6a5629ac61d3fa77e7c6c3339260280de1114da7c4e1c9862c2a001da22748e4670c39e0287",
-        "dest": "004_carData.Rpkg"
+        "dest": "005_carData.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/contfrac_1.1-12.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/contfrac_1.1-12.tar.gz",
         "sha512": "fa22fa5404c5917e8b33f1d5b4c7af8cf7a66212840b2d9cfed40230a0f74eb4ba0f9966248291ab08d6ecf7e94ac5b8a544e16297a6a30426a95d88f72833b7",
-        "dest": "005_contfrac.Rpkg"
+        "dest": "006_contfrac.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/cpp11_0.2.1.tar.gz",
-        "sha512": "cca34b1c8323c48c6fb049894e01851407590f285f7f13ced0ffcf1a1f3273951381b61f31e1a27cd246ce0b71d8c297bb1809c6a349fdd20bff3e264db7496b",
-        "dest": "006_cpp11.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/glasso_1.11.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/glasso_1.11.tar.gz",
         "sha512": "eb82ccd8598900fc696b9e6f0d4d14d2b2e02c61786889b4aa3eaada85325afd7d136be2dc7767d9e380b30174ee5b259c004dd2606ad448f177b245597697fe",
         "dest": "007_glasso.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/jpeg_0.1-8.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/jpeg_0.1-8.1.tar.gz",
         "sha512": "f7e3148a54a4414505e3e3066b39634877ee9a69820df3e83e3593e78a6fd4d5047a5bd7abce8558149cd1e6519a13dec6d2b8412da8b396a73f3b661d2fba31",
         "dest": "008_jpeg.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/lisrelToR_0.1.4.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lisrelToR_0.1.4.tar.gz",
         "sha512": "3ca8fc6405484d9b7c09df985caac3158c8e7c1b16526a46eda970e1b68acbe9ce278f825b0bb13b665dc7ad6d012ef0cd393c21de499022a9b6f874857e64ee",
         "dest": "009_lisrelToR.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/matrixStats_0.56.0.tar.gz",
-        "sha512": "75190081c38af4e14183adffee02422466296643e9ddd587fd684c7c653396c5c7d3f47c8490533815aa18182439c4db8a7f8b66913dd2114b83171f5e9c7f06",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/matrixStats_0.58.0.tar.gz",
+        "sha512": "5f57a8a530619572f3c94eb9c4b997d3aef62a3932c6ff933423a6498407999dfdad9d8608b1594e6b173acc490925f9c4267df9add7083c5613a912353530c7",
         "dest": "010_matrixStats.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/matrixcalc_1.0-3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/matrixcalc_1.0-3.tar.gz",
         "sha512": "ce7a5e026c951a45c9c8d305515457241d48ab53681167d684c32f3303492661c364afe8388c8ffb6716830c55ded9fa591ab06527e5bf0c31943491ed8f5b14",
         "dest": "011_matrixcalc.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/nloptr_1.2.2.2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/nloptr_1.2.2.2.tar.gz",
         "sha512": "fc553ab44f30d0d67be7a1a6cb67e24a90b74943505b3331e7f8f474bfa58a4655b23137c88d350472d4b7ffcb34503ba7ae81692948c4943600a2793e33ccc7",
         "dest": "012_nloptr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/numDeriv_2016.8-1.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/numDeriv_2016.8-1.1.tar.gz",
         "sha512": "20e9dda1af54ff581f4f9218c34af204de5b78bb21eed88aef836ea215c37d90f7af8f1d972436316eab80451f531e1c9badb34f33001e3441a583a3ac4776e0",
         "dest": "013_numDeriv.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pbivnorm_0.6.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pbivnorm_0.6.0.tar.gz",
         "sha512": "44d6a3edc899533d392009034037b8221e5c94ad570a4d91789c0c23971f4385a4f317651733c92366146fea75db9f84fd33bebf8c56e90ea6e4139fd924bde2",
         "dest": "014_pbivnorm.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/png_0.1-7.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/png_0.1-7.tar.gz",
         "sha512": "033a2a45e0fc55a9975257397162ceac0416afb47bbf266025e1ed00790ea1261d1254255aa09cd8828e034b0cd8006cc5e26c9f732ec996dcbec3c937e00f5f",
         "dest": "015_png.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/polyclip_1.10-0.tar.gz",
-        "sha512": "53a1ab0eca17178da415bc9a40b661ab2d5d3341de92a72b02c848ca636a7abc29b66ed9e78c929ec76685a698ef1b83524aaf90d83d4b41b4a1ed2c3e083d03",
-        "dest": "016_polyclip.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/qvcalc_1.0.2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/qvcalc_1.0.2.tar.gz",
         "sha512": "a3db18c43ab9d2eca6e604f465aaa27a56a04b46e51f75b032ceab5f2e1d94829bb02257c9dbecbf1e9a281ca28ff98e1571262fa6c98960268e9c3cb97b9b4b",
-        "dest": "017_qvcalc.Rpkg"
+        "dest": "016_qvcalc.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rematch_1.0.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rematch_1.0.1.tar.gz",
         "sha512": "b97c4d8c4d8fd3706e8d1f97eb1ea21fb3cd45289933bf4559b5131b6cfae37434a7fae5f2bd07acc8bb3b9e40874bd893b7a5e5bc63d6a4dcf624a5d51f0ab1",
-        "dest": "018_rematch.Rpkg"
+        "dest": "017_rematch.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rjson_0.2.20.tar.gz",
-        "sha512": "6afdef0a192ef538798f5e58d5bdf1109749d54261febbf522eed8dac98ef36a5b7a2212b4b4b0fe8af5204c808f9cce719bb82ff3ac6427c665bf5ca5d35f42",
-        "dest": "019_rjson.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tmvnsim_1.0-2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tmvnsim_1.0-2.tar.gz",
         "sha512": "c70ac65ad1e3e632d4a3ed5d2a72ecb20c9b303263eb5ee0b2f6cc74762155c28e359579e202e8fda373a1effd280bf640dbe603e4520104fe84039cf333aced",
-        "dest": "020_tmvnsim.Rpkg"
+        "dest": "018_tmvnsim.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/truncnorm_1.0-8.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/truncnorm_1.0-8.tar.gz",
         "sha512": "e45a59be9b35a95bfdd7bf9a29d72e9483969a3c327107b9e338dcc9c58db38949dbdcc8f4d4ee64ee861e4eab6690e14601a3ccc197dce0ba6b93ac4c73ae23",
-        "dest": "021_truncnorm.Rpkg"
+        "dest": "019_truncnorm.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/whisker_0.4.tar.gz",
-        "sha512": "257dfcf9f8df6a59004e21fdad3a0e0958b4070e7d293e573ef8b4a237d1e3cab049384ddb266d9a5ef385564c3aef265d82e275c9bb8c8baa608ed88ab95584",
-        "dest": "022_whisker.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/zip_2.1.1.tar.gz",
+        "sha512": "17831001fc767154425b19a230e07cbe50797fe3e767a680da70daa5c49634f48f2731f0260bc54c18a41219d8a30f3df5f10246435793ad183638794b025a24",
+        "dest": "020_zip.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/zip_2.1.0.tar.gz",
-        "sha512": "ac46ac96d0c78b0e4e22e6efa839502c636fc3e17b17d1d40425411862213e2e2596170f8f9f03a8b91c53ae09ca86d851c1662afac122a6c256af8c759efdb5",
-        "dest": "023_zip.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Formula_1.2-4.tar.gz",
+        "sha512": "9fa7bf9710c37ae28454b533dfe82cc602b0ddae4ecae38e31155cd957cba51060ba84fa0bbc3adf65aa02d0a2c56fea3a852da292bb71d615437fbdc246a741",
+        "dest": "021_Formula.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/Formula_1.2-3.tar.gz",
-        "sha512": "4ca08831fd1d405df64cfc4dd2f4fe6d170a7533faf6d17f74a51dce600cbe7162c583095650c409ee544caf12d5d144c05909a257e9cfc912f924a4da645b26",
-        "dest": "024_Formula.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/MatrixModels_0.5-0.tar.gz",
+        "sha512": "4804ad8dfb596697ecfd37ab013d7c05e8e99716ed2ed7a87180ad45e2acad21bce9e5742e6d812582b399155c33d9e29e2610f9ec98c56d9229c51ca9a44339",
+        "dest": "022_MatrixModels.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/MatrixModels_0.4-1.tar.gz",
-        "sha512": "058c229c7a56e06c3b38ed1e93ef4ca02ac73f91a4c7536a892a8d2579c5ad75ad4b726d1b8efd5f0389e6584e6abbd4c8715d190d573c1f1aa13f9efd7fc665",
-        "dest": "025_MatrixModels.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/PMCMR_4.3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/PMCMR_4.3.tar.gz",
         "sha512": "56d9785468f3c6c6abc0038ee019bf93ea48dd29c42b74d03f3d11971a9695072f41b5b20c65dc361acfdb4c57e6eb39d7191ab23f46a5cdbfc5d90c89fdd6a3",
-        "dest": "026_PMCMR.Rpkg"
+        "dest": "023_PMCMR.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RUnit_0.4.32.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RUnit_0.4.32.tar.gz",
         "sha512": "5df78b0b653cb122e8edd23fc95e00966c5e54ee5db081efb216e88847d8e292fb69af27932a35f5d51ebaf3a162128fd4a604b8d1e2dc8dfb6a8a72345432e7",
-        "dest": "027_RUnit.Rpkg"
+        "dest": "024_RUnit.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RcppArmadillo_0.9.900.2.0.tar.gz",
-        "sha512": "cdbe2fa9f496201e624025213311a9d20607d378169a19e4b6354c207e14862ef7ce767dab64d4a7b99f88561c740e3e5bfb6027bda73ad5ea9616e3e0990a38",
-        "dest": "028_RcppArmadillo.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RcppArmadillo_0.10.2.2.0.tar.gz",
+        "sha512": "b068fae82278165d36756658fc3813302ad253bddc3d869034ab0fb81519596ca396e56bb35fe8cae372ff2d4557b55a52522698fcd6c2f30867c1f1b557b662",
+        "dest": "025_RcppArmadillo.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/RcppEigen_0.3.3.7.0.tar.gz",
-        "sha512": "91965c68dcea319fc81d227738936ab1c3c1f62f102816e70bb4f563ad91f721abd4026830c79d5ad0644461848c4db1d66c040186ccd9c05575fce77946d498",
-        "dest": "029_RcppEigen.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RcppEigen_0.3.3.9.1.tar.gz",
+        "sha512": "9e5d88c31d49c9dc3054c794313b1c9796e2b9538b667227631c5449670531cb1c7adb42a27701e3fd1939c889e7da742fd7aa56e20bf54445b4295c92d90eae",
+        "dest": "026_RcppEigen.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/Rsolnp_1.16.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Rsolnp_1.16.tar.gz",
         "sha512": "d58becf1b89794f9170246758d786547e1fa475aba1d64e681bbde8d5bf6a9ed507589877095adc3584139b8085f7107245f1ec1737d10ee7d314222f47d11b8",
-        "dest": "030_Rsolnp.Rpkg"
+        "dest": "027_Rsolnp.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/SparseM_1.78.tar.gz",
-        "sha512": "bff92ebf068017ddc65440bc589c77037d42183d7ce535e09f0b6beb4a072743bcb16129ff435cdfa78095bfd153a52a0ae6e0c326ae8a54e21d9783431b73c6",
-        "dest": "031_SparseM.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/SparseM_1.81.tar.gz",
+        "sha512": "3fba6796a48a32059e9b7a7a22302c251a57abaca3c8a90dd531a9f7d201cb1156b65382b00b3d9e4dc919031d7adbe9c7744304401974c81063ef23d98fe126",
+        "dest": "028_SparseM.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/TH.data_1.0-10.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/TH.data_1.0-10.tar.gz",
         "sha512": "adf4900e88f33cece07088a9bf64c57fb7cfe850f287a531d5690d67c68922c71855efc0d591e58f1167ee619b23d9cd730656bec5c54bf9f9883cfe1dc4dbbb",
-        "dest": "032_TH.data.Rpkg"
+        "dest": "029_TH.data.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/XML_3.99-0.5.tar.gz",
-        "sha512": "43737430783d905cd1df0831275047d27d0adf7f3ffc6d4e19f1b2e030e13e2bbbc1fac5de7db7548c43e3de5c79db1dc918874a862c379b8fa2bace6f43fcdb",
-        "dest": "033_XML.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/XML_3.99-0.6.tar.gz",
+        "sha512": "ad18cd2eb0e857e5b7f53a3db5729cb4be4f4a98b3b84b97108595497f85363858910a0d3e0a3134776cd978da75abf2bf00854a99bef797d88e9f80a081c5af",
+        "dest": "030_XML.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/abind_1.4-5.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/abind_1.4-5.tar.gz",
         "sha512": "b1f5d716e04f748b9d189a4a3e15ad00c2b5a7c69425dbf9f36fcb4fe23f6ff5cec2eb22ec626ab194c1eb88bdfd271b535868b00157efd4acf0faa022d16987",
-        "dest": "034_abind.Rpkg"
+        "dest": "031_abind.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/caTools_1.18.0.tar.gz",
-        "sha512": "af9f5e3d6b11e7f6e95e59051544f2d54f4f17b3a548fc6695204b9bb94592a5cef50b2cd5ce3787c85e1d022605b7528d1b49b06a6604ec377811a51388930e",
-        "dest": "035_caTools.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/caTools_1.18.2.tar.gz",
+        "sha512": "79f34877a58322857da2595eb977ba047ee97dc25420921ce1a29b5060bc2082f38bc2ec4afd0f3243bc1991c86353e0d12cbf593ad5241623a4abae8b023058",
+        "dest": "032_caTools.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/cellranger_1.1.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/cellranger_1.1.0.tar.gz",
         "sha512": "5a27ce21b5d22b0eea06f64ef6faf26a63860ccefa17e3d4cb74ffceaf8b0b6f332b482d476dbc32f8174d5bfef01a5f9fc20673db2fa5386682be1baf11d2a9",
-        "dest": "036_cellranger.Rpkg"
+        "dest": "033_cellranger.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/checkmate_2.0.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/checkmate_2.0.0.tar.gz",
         "sha512": "8d575d79744157d21e0e6492f9107ede62f21bc2ba6c372853bf0f19b191f4bab01397f015f99384e331bcf1a300215a541528c0d60a49dca05144332af51077",
-        "dest": "037_checkmate.Rpkg"
+        "dest": "034_checkmate.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/clipr_0.7.0.tar.gz",
-        "sha512": "5139524fde07cd070b1699560548621a8913aaac24e6d3c54908a4f50482c10f3355ce71868ab12fe19bfc41bacc902f8077b85cb7d806896dfcb60d4b747297",
-        "dest": "038_clipr.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/clipr_0.7.1.tar.gz",
+        "sha512": "1c57770f3c765b2ebf8be7146dc7688476900368a4845506cbd21d981e33f53093bce9178c76698f4fc8eed1b3fd086ac4ad4dc63a4682520bb97e49e4ea0839",
+        "dest": "035_clipr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/coda_0.19-3.tar.gz",
-        "sha512": "1833b7a8c7de5220455d101ce4f14348eb750deb245a82d994810fc16b4c01efdf6782ea6d6442ba325ba8cba57d8c0439892fdf15f4bae85b95f2a2eaf28221",
-        "dest": "039_coda.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/coda_0.19-4.tar.gz",
+        "sha512": "f390a76658fc49da236dfbf04c920a9cf148ee6ecbb4ca595b6c5a20e8d87a749e67fe294ce63781a277b51b31741508197f9939b62b1edda03228022a02c950",
+        "dest": "036_coda.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/corpcor_1.6.9.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/corpcor_1.6.9.tar.gz",
         "sha512": "8e80794336b6526564c0ecefaa17c3a063d8a5913cd0dc1fc3fbde65d50821cadb097031607bc129be0e742d2ba9181e9027d0b692477cfa299b6e569af4908a",
-        "dest": "040_corpcor.Rpkg"
+        "dest": "037_corpcor.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/data.table_1.13.0.tar.gz",
-        "sha512": "a56e8a5921c3c1d488bbc022a4ba56ec55d1bfe7ac6b783a642d4c8bfeae3668be5727c4f65dc12271ce7c1763612657a969cd54d5e06438874a4f2be5164cfa",
-        "dest": "041_data.table.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/data.table_1.14.0.tar.gz",
+        "sha512": "db90998904270f42cc654faa0b333f8e720e4044c7f2c82f52efbb69e1ed30c5b2c1b034f7a5baff4543151eda7fb33aa454817889ac95a5d17d6aba364396df",
+        "dest": "038_data.table.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/deSolve_1.28.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/deSolve_1.28.tar.gz",
         "sha512": "85dc2ef3439edbf4406d78b469be1c94a087b55ca595960bcc00653984d927d1bf26670a46c73656bfdb6cae2ef6e1741e97cbfb690fdbf1040cc3f69cf157c4",
-        "dest": "042_deSolve.Rpkg"
+        "dest": "039_deSolve.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/elliptic_1.4-0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/elliptic_1.4-0.tar.gz",
         "sha512": "6569ee1695673c171822007661c928dd1e7493aa5c64463477bfb5d354027f3181d174c217b5794ee9efafd8078ec8dc89bc9aded912d81d1c0e4207f9a3b2f3",
-        "dest": "043_elliptic.Rpkg"
+        "dest": "040_elliptic.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/estimability_1.3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/estimability_1.3.tar.gz",
         "sha512": "83f707dff5f85eebdb9560314a1e4717a17c97a4517ef774b9a6070bbabe63f0940c87c8b1aa1e5b750a5ca8ecae09e051c57579217284c1f4ca005ce323c952",
-        "dest": "044_estimability.Rpkg"
+        "dest": "041_estimability.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/fdrtool_1.2.15.tar.gz",
-        "sha512": "d5cb3401fba0b6898e5a9258e74f33b1eab82be8872e2c8a242ce2f5e7fe850b06f4419e39b253ea8065db9c8e923e028a36338545bdae8e88773c0b1b917de1",
-        "dest": "045_fdrtool.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/fdrtool_1.2.16.tar.gz",
+        "sha512": "bd9da5eb9c5345fa523f828660e365cc5bd70a7d637c3149acd3dc3fdc76942e5962aae8cf93ae145f74e4af1e99aa576ed50ded9c96897c7e5a328094d3afd4",
+        "dest": "042_fdrtool.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/forcats_0.5.0.tar.gz",
-        "sha512": "75ba1a67355f3bb19308e539bb6e5686c8a4a8e6847c467c0d1cf8f7493b64a8fcbf7cfc0b13e3e7a482458aeb3ec68eae4a312e8c2437826b084bad68a9a712",
-        "dest": "046_forcats.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/forcats_0.5.1.tar.gz",
+        "sha512": "44b3e90e764afe4a2a7339e72a8c01c053ba972611a194d7d278a4bb7c4959b0a514a0ac1f2c41a82219060e699e961b079c1edceac52fa1d42e53e7c2d15b97",
+        "dest": "043_forcats.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/generics_0.0.2.tar.gz",
-        "sha512": "ed6e8eae7697436763fa13e6114c78c2432ad48cd355edd6f41dfe96c461a80d8f37b27290f0aff1168567566fe8b257dacdd7cd14d0e27d3a7f4b1c047e119f",
-        "dest": "047_generics.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/generics_0.1.0.tar.gz",
+        "sha512": "fc96efafe114a66eee57aba48b7ab763204c1bb43570eeda742bca9e7486b47a0bf01bad87f2bf225a5c67f0abaf60c758afe7dada049b692ee864077334616b",
+        "dest": "044_generics.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ggrepel_0.8.2.tar.gz",
-        "sha512": "c4b301c1bbb51b2d421a219a0c717b2a646c54dfa9fbfd324f08eb36b00db5da246bc2de0829cb74d11e42f8923117f0f99cf2353b5ff8ff7d75217a4d760ad7",
-        "dest": "048_ggrepel.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/gridExtra_2.3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gridExtra_2.3.tar.gz",
         "sha512": "916b5d64bd17295855d4c81b628e900cb16b3eb3b7b0f25ee00a91bfbaf480a0785797508c4671031bc3f2a71a32fa3ecc828420fc33b3139d7e46b3bfefca68",
-        "dest": "049_gridExtra.Rpkg"
+        "dest": "045_gridExtra.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/gtools_3.8.2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gtools_3.8.2.tar.gz",
         "sha512": "08e3a6548a5078a241e8cf335d2bbb5ea8d09e6ce4865dbb84699faf2c96ad00534263d737c9f818c602b108009390bee3a86b5671f04d1d9213201e8d7ab6d3",
-        "dest": "050_gtools.Rpkg"
+        "dest": "046_gtools.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/hms_0.5.3.tar.gz",
-        "sha512": "acc1aec4eaa40f9c0613084594c55104dba5a82f52a3222dfce375aeda1c62844e47cd7b02c7f1d84794700c5ddec38212b17bc6b1c28e266c83c968225abf59",
-        "dest": "051_hms.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/hms_1.0.0.tar.gz",
+        "sha512": "3559bbb4e8780770f242ba53dcb5920fd164a7b9fb3f6e379acb9534444f544ad59fdd33eea13194849787f16f418fb8be39239f030fba9026e5ac2184d0713d",
+        "dest": "047_hms.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/htmlwidgets_1.5.1.tar.gz",
-        "sha512": "efd1351c0d1c41baed3d649c156ecd88643e4e9658075c97b0ec562c336ca11b8030945bbcf27a03b9b1a85c7e09b90e89e151763b5c7c3fa79848e04c38ba68",
-        "dest": "052_htmlwidgets.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/htmlwidgets_1.5.3.tar.gz",
+        "sha512": "6f7551f92f7ac76c99044651c763eb51fb5f82bd0d03b890698e0a3fca80e2ee010cdf5c0940c6b8a4ebebf9861d3c343d3cd1ac1953b08011fb3cddd11a6b75",
+        "dest": "048_htmlwidgets.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/igraph_1.2.5.tar.gz",
-        "sha512": "627396fd4043fff640cb5a4f864613a43fd9042a50b60a55dab6c82857bb81dd72d0c1447b6267282a613550130e420c7b229306152213252d7733ec99c55102",
-        "dest": "053_igraph.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/igraph_1.2.6.tar.gz",
+        "sha512": "1acefb09abeaf904c5934399b883edff200445ced6b7b5a3cf17041d67a128d3d656f6ad5ebe407ea3dc7277b7564db5fb21dd462ec15cd25ac5f9fe9adbe996",
+        "dest": "049_igraph.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/latticeExtra_0.6-29.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/latticeExtra_0.6-29.tar.gz",
         "sha512": "f6730a33b852f336d67bb8f27b8b67e1622700e5f64e1f269355fff4034e928e191c9cdbc357c6fa6eb1eef44d34fdbe143f99531d272d993bc583764be7211e",
-        "dest": "054_latticeExtra.Rpkg"
+        "dest": "050_latticeExtra.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/minqa_1.2.4.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/minqa_1.2.4.tar.gz",
         "sha512": "1f21e661b6bb8bad5074d2ac579ec0fa031a149c52dc22bc5d73927bfc71ac9bfbf73b01730288f5f4a9930aca53e838e028772996b2860a4f5578a151f61967",
-        "dest": "055_minqa.Rpkg"
+        "dest": "051_minqa.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/mnormt_2.0.1.tar.gz",
-        "sha512": "408d298173f3b5908da468d8db7cacf95965cc347ca6bc25223520e495027d4b8bdfc10775abba6cd1a9ceae1ab0f7ca31694b05d28b15f8c9c6dea28ae1530a",
-        "dest": "056_mnormt.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mnormt_2.0.2.tar.gz",
+        "sha512": "36cc5547be970c6e04fdee4c0442e5d6851f4f0fe2f8234b708b54cdfa6487b67bfc1347d7d4e3eb20e823a27befa1b9da2c860eec10c29f230106ef851757b0",
+        "dest": "052_mnormt.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/mvnormtest_0.1-9.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mvnormtest_0.1-9.tar.gz",
         "sha512": "cef4d945feb7faeffd5e68fce116c4f9fcb03f5c601dddd47f88f9ddf297bee90c588587c2033c7b7c40d825c972303fb2f38077e8472b4d35e4bd92af1e6648",
-        "dest": "057_mvnormtest.Rpkg"
+        "dest": "053_mvnormtest.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/mvtnorm_1.1-1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mvtnorm_1.1-1.tar.gz",
         "sha512": "ae7e10f45594c31ae9fdd45cf011fbb82d4835a5ba971fcbac3d451773ba17f447bfaf2048c9a790d7404280eff820fc7b875ab38350a20445f781fc19158340",
-        "dest": "058_mvtnorm.Rpkg"
+        "dest": "054_mvtnorm.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/openxlsx_4.1.5.tar.gz",
-        "sha512": "f7231d3e2a6397fc93dfbe711e95074f69cd66b34d857212cd71dbeaa5a78977a93edf61073aa627558f7c3cbc85cd72d5855da76cd46060e9a30070ccc92741",
-        "dest": "059_openxlsx.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/openxlsx_4.2.3.tar.gz",
+        "sha512": "72027c4d2c4c6f4b4728c2a6edbd4bd75a15b2d46f99e5c41dfbd2109f2ab5f91bf72d21528ab72aa23c4b22a9370a63e07871125cc22a6192a70a993453b756",
+        "dest": "055_openxlsx.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pbapply_1.4-3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pbapply_1.4-3.tar.gz",
         "sha512": "ac354dfdc672b556b1299ce54127db68cbc7fd3ff36e37bd5a58401261aa6e6039814a075a7bca612b49c0d4d249eec691e56ff800b85b323b4fe29d5650a75c",
-        "dest": "060_pbapply.Rpkg"
+        "dest": "056_pbapply.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/plyr_1.8.6.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/plyr_1.8.6.tar.gz",
         "sha512": "2c41e77b338055fbc500cf3c5e1f8b0e8339692eb18b63edceca92f4e4ba4b3930d718b59da79ab459230f4177de718a034069bbf42c1b0e47b97ba99dcacec7",
-        "dest": "061_plyr.Rpkg"
+        "dest": "057_plyr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/purrr_0.3.4.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/purrr_0.3.4.tar.gz",
         "sha512": "30f121c751e6c85b986b872ed1bae6464d2f0f3b79493537d4f1b673d55725218dd982a2ed7b8b8a12b2aad586db3133e49721812f35bf3b2c692612759bb2ca",
-        "dest": "062_purrr.Rpkg"
+        "dest": "058_purrr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/relimp_1.0-5.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/relimp_1.0-5.tar.gz",
         "sha512": "46a73aee8aedaadc4a703d9edf25079fa994b36cf696d15e5e7da270440a3ee244fff1a70bac2ff24bca813b0627a092d2626416bca9d7e967cd5cd529ceeccf",
-        "dest": "063_relimp.Rpkg"
+        "dest": "059_relimp.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/sp_1.4-2.tar.gz",
-        "sha512": "b3d2c07dd5c5defa4e6c1b4d595659b46726f763c14ef0d60ed7ff871df04fbbf59fc2671b5feb4061fc4c66fc8e1947f15943943f39dc6323fd1b4fb4ae664f",
-        "dest": "064_sp.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/sp_1.4-5.tar.gz",
+        "sha512": "c5773c369a6aedcd13b8da204f987914da21590dc7bb45eee29592ab68ffa0962790f1a8aa1f53126fcc35ee80bf0a29107cd7c31b6412eb27be5255c6ee2002",
+        "dest": "060_sp.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ssanv_1.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ssanv_1.1.tar.gz",
         "sha512": "ccb43e466bb50a3816a609503811eaf59eafec405578356cd8fa5ef2bbc646aa23e28ace945a394ee7129f4aff87ca8cd7ebd946eacc71f23a0d8e9046894c64",
-        "dest": "065_ssanv.Rpkg"
+        "dest": "061_ssanv.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/statmod_1.4.34.tar.gz",
-        "sha512": "4f615dcfe12b94049d411fbe39fac3b6df9dd3a2959c28e22c57ee57dc980f88a30290de8a6652bfe5898a2c23e031435f97b76ac312cade9ec23d9c0ce19278",
-        "dest": "066_statmod.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/statmod_1.4.35.tar.gz",
+        "sha512": "0163a72488446477daf2132522cf04dac4fdf847df1b39dd708c888108917927a0509ce92c102142657a0a2121cbd6c12c3672f581bebc36611430abc6881217",
+        "dest": "062_statmod.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tweenr_1.0.1.tar.gz",
-        "sha512": "52063430057843b276a037108b2a757a373209fea9defb248a8803d77e31fbbf04816f067dfd2dd5c6c4220ea055fbee57014ac7482164213b3c6e496a4a6c94",
-        "dest": "067_tweenr.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/xtable_1.8-4.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/xtable_1.8-4.tar.gz",
         "sha512": "0143e22d3fc60c30159387f1614ecb269bc90d8d7a32d10f7f1e7f77863dfe33a71ca95cb1abd7b3d0f889e26a63d16e60dea4a1d4a33bbcbe6b5c823ed96b09",
-        "dest": "068_xtable.Rpkg"
+        "dest": "063_xtable.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/zoo_1.8-8.tar.gz",
-        "sha512": "5d16ec649ec6b046e4130c9a8444d76c131d5bcf532f0f37ecf5fffc13a1c69c637abd735162e7ab2e5b1831f9d29a84e263432cf3a65e368b917d028326ba42",
-        "dest": "069_zoo.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/zoo_1.8-9.tar.gz",
+        "sha512": "c5516542fa8efc3c83d1dfaafded3f4f0f0bc32549c07f2512291951e2d783c39705bbb315437cd0a666db18b8d987f7b25d2ec958cbdb19b1a3270caf15e940",
+        "dest": "064_zoo.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/BDgraph_2.62.tar.gz",
-        "sha512": "61e77fe5c09f7bdc1c66271c474e4a8e9599e13880a109283b9f44c830c05b6845ff593691ce23cfe7dcf2bd7b6b7d12ab56d36fb0fde90ac494b033be87ead0",
-        "dest": "070_BDgraph.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/StanHeaders_2.21.0-7.tar.gz",
+        "sha512": "474637f3043defb4b646b37b12469a7bc9df823f954e9b5cd788063e702527065da54cbfb5f3829c44912e07855f403f00962149277a8f7c5f694319b30a9556",
+        "dest": "065_StanHeaders.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/StanHeaders_2.21.0-6.tar.gz",
-        "sha512": "fe6160562338377e814c13bbe80fa59ee1504ba1a73a5ace2ea00c513b09d1aee7e07446a292f3d434701db29c58db2a3ff90fd7dcfd7c4b12758fead8eb2416",
-        "dest": "071_StanHeaders.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/conquer_1.0.2.tar.gz",
+        "sha512": "835f6b89c6e1d28abba78aa3b8097e68e027035a6d609ca56ff54f32f2023b245e3882aada74d0a7dde915d1f444041dd850265e6d2970b0ce974db49007928c",
+        "dest": "066_conquer.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/conquer_1.0.1.tar.gz",
-        "sha512": "405f21135cfa0940a50bfa4e8d71e1fe4c1084586509b0bb1e164a1f947a57679c2d8c49ecf19f32f1bea175480fd419993a3bfd623ed12a87998b3d5027c5b6",
-        "dest": "072_conquer.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/emmeans_1.5.5-1.tar.gz",
+        "sha512": "5b5809750d1fbc36f6798b182360abb1dcad52a12ff9890eaa687708c6bc1ed4846bbcf047357184b81736df24e6b26cfc1d6bdda4b27d24f5d8049ed24ca195",
+        "dest": "067_emmeans.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/d3Network_0.5.2.1.tar.gz",
-        "sha512": "669af1a76b85dad56caa742d8c17564b49f4cd7cf9b371f97fe9c57d4b85fd48df9e6838db1db8989ba75341fdab0b96b46a2995b9cd155cdf28e236c6ff329c",
-        "dest": "073_d3Network.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/emmeans_1.5.0.tar.gz",
-        "sha512": "c0b37135ce391546ef146545f7ad1ce16c021259bc61c9a3af9eb945ddc67f103d2a0ff5b6179f2a716484cf62bd3b22cc5d729af134a50ad4b25d3452c768e5",
-        "dest": "074_emmeans.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/exactci_1.3-3.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/exactci_1.3-3.tar.gz",
         "sha512": "2f424fd7ba4871794b92f6487477cf7b8da857f4d25da34bd2be3a85289b4e54ac0431b909a602790afc05f7933085b50c4cdfb70fef7cd374626f28313ab67c",
-        "dest": "075_exactci.Rpkg"
+        "dest": "068_exactci.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/gdata_2.18.0.tar.gz",
-        "sha512": "609a412970d46bed0d12191b1015fac96b48244cb9fb35506be07ae0544583566669c0e233a52f418dafdfc787a92cfbbf6554cb336af06c257b3bb6058e4fd5",
-        "dest": "076_gdata.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ggridges_0.5.3.tar.gz",
+        "sha512": "3f9518d3138d6e5b990e188d38203213c172efab2daeedb580f6253692097d378bd4ddf57b92930babb445862fbca259f0ee297b535da72ad9194c8d2748b484",
+        "dest": "069_ggridges.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ggridges_0.5.2.tar.gz",
-        "sha512": "347e6fa5c95651b947a67838455fc23deaa961c475dcf64b04677712fac5271d400a1665e12b6a417e4fedc6265790901115a066e1823ff89fae60dd39da1283",
-        "dest": "077_ggridges.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/gnm_1.1-1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gnm_1.1-1.tar.gz",
         "sha512": "a753c9387530e32db749e69c794664213e9d38c61ced1ba5d0677bfa7f54a7d3df59abdc94810a14d59b89dd5473154de01fd8d7de7c164597c3a252353be053",
-        "dest": "078_gnm.Rpkg"
+        "dest": "070_gnm.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/graphlayouts_0.7.0.tar.gz",
-        "sha512": "d082a65c9ab0ab2fb5fc889a226011daec2a9c3a4d142b9401e84b6cbf089ec3e877fb846aa5a0c347892a2c8d4de09de161325979eb6abcc0063f6c98ae4476",
-        "dest": "079_graphlayouts.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gplots_3.1.1.tar.gz",
+        "sha512": "bcd04d1369a05adec99a915d69eb2d419d987eb5bf4f78e1b2ab7b3406ed1139e830e6abad8b72952984c5f4ac51790bf016e7e79a18355816dede8101c73a6c",
+        "dest": "071_gplots.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/htmlTable_2.0.1.tar.gz",
-        "sha512": "7fe8c00869307d3ca5233e5c34915a99070e700bc123c2681fb7531a043a802394402acbf8e9705acc472158b2fe487ab73d05e2847bc112ec73a355aca04863",
-        "dest": "080_htmlTable.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/htmlTable_2.1.0.tar.gz",
+        "sha512": "a9753832be81024c51993f36981b539aef57f1f044a1c5c6dcbf0d4a3b5ea615a63f6f1fa70f5690ae4286f6937c14929b33d3d3d4d00a8048c4e8b575a73f40",
+        "dest": "072_htmlTable.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/huge_1.3.4.1.tar.gz",
-        "sha512": "77004fd982dbb258b0f16a316385216c5abfaa49f6e373c365b965dcad5c9d09c3d5e883bb420a3d4e52ed869dbe8b811ba4857b2fda3714ea24989795c7175e",
-        "dest": "081_huge.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/hypergeo_1.2-13.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/hypergeo_1.2-13.tar.gz",
         "sha512": "7e3c0b89bfb849325511a84df341711b513a8f2c7ff6ea40787e7253b0e5aa65a6cba396bef46a43047ff42bc2692f5fc8f258312eaeef384b246d845873296b",
-        "dest": "082_hypergeo.Rpkg"
+        "dest": "073_hypergeo.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/kutils_1.70.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/kutils_1.70.tar.gz",
         "sha512": "618fa364786cd23aee043266aedc089f1bec44d81b2a64d5f3e189fe8f601fbc07c513d96143e330e730ebcb10269a46e2c3187315e6575551804ea04b18d2c8",
-        "dest": "083_kutils.Rpkg"
+        "dest": "074_kutils.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/lavaan_0.6-7.tar.gz",
-        "sha512": "df847aa28627272ed2981f1fa8015fe04dc3c9224031cdb55f7fda89a553aa13294004bd85c6bcf63f7ea0a5ccfc683c4254bcbe46ccfd3a2bb42acc99d54b1a",
-        "dest": "084_lavaan.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lavaan_0.6-8.tar.gz",
+        "sha512": "265ec8b05a7dbc91a040f2e4f8e3fa7691781a3e82be5e3b6fc93ef730797e7f5f91c22c4ef354e8274b4bfa3a5df185dc6d1f4f6e3d3e0d963f1ecb30912033",
+        "dest": "075_lavaan.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/lme4_1.1-23.tar.gz",
-        "sha512": "8384e8f05ce2c87272606a9676091c8b931bb7fa61b7f51787b564e5aba531eea3141d115480a6d9d1cbfc95373f4687cbb74544eb390ec629b416a31a9df1da",
-        "dest": "085_lme4.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lme4_1.1-26.tar.gz",
+        "sha512": "e28d4b93fceb9ac3ba44ae8d8521ede9f9e3b4c7a079f6fbe306300846cb8589eba48dc401764c747072ca6a10a857c3a24a1b68c93db98927d5060ec81aa673",
+        "dest": "076_lme4.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/lmtest_0.9-37.tar.gz",
-        "sha512": "2d58a5297b00dd227f5f5187a1be0772c6bb3acc57fbccd32a3673579460cd530d19466e0b49ce9eae91544a003ec19d538c495629a89600bed2bf7e6895292c",
-        "dest": "086_lmtest.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lmtest_0.9-38.tar.gz",
+        "sha512": "191ff072c8dde7b122f30d2025263348b3a8e742967e8442fd9dfdc89c1535466f8878d742ebb821c250ff5c219aaba5b6655d29abdca8e4cb7700ae6788917f",
+        "dest": "077_lmtest.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/maptools_1.0-1.tar.gz",
-        "sha512": "0432d0afebd30a01d0eb68a92b42b0ff029166978669c21bf126064291927888bac26c4d4d93a5e1258d81478c89b368693cf7c8aa16bdef85788f3700a83c1c",
-        "dest": "087_maptools.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/maptools_1.1-1.tar.gz",
+        "sha512": "069530531e498c62bb363da20f799ab7d63db4400844cec376b166c70dedd9fdd4070b25918408a6f707298f355b9dc24ca0ddcedb7a9dec556b900c924fd32b",
+        "dest": "078_maptools.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/progress_1.2.2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/progress_1.2.2.tar.gz",
         "sha512": "c02dfd93f43ac82ea44b97e53dd9e570aa90e95c8e4a9088114bae77f573eaba536b167a27d6a6a48d6db1d0b21d59d22468b48c0ce9580862af35f7bb3ee0bb",
-        "dest": "088_progress.Rpkg"
+        "dest": "079_progress.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/psych_2.0.7.tar.gz",
-        "sha512": "0855a480b1cf62c8349350a497fa2125e803c4d488764c1630c93c1e7334432916fc70fae6d3047928d7b51480aaad7228e50f5fb309442412dffa7313ad6790",
-        "dest": "089_psych.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/psych_2.1.3.tar.gz",
+        "sha512": "97b4c61c1f2e30e002f4998336553d72107fde9a0b7f590391dea1751d75479d9fa25a45e75cd59987bc0a1f91af4a29b035d300b0cd2a567bcb37a9b535dab5",
+        "dest": "080_psych.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/readr_1.3.1.tar.gz",
-        "sha512": "343079275436fedf6a6c539692cdf23a7b877c2f62c439ab030fb72aa145bd39bf8d2574aaf095e1c6baadba1be3ae44789e209386bd27cfe1c8d1512d14b9fd",
-        "dest": "090_readr.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/readr_1.4.0.tar.gz",
+        "sha512": "516059e44416c097ebfff6d138e7c4e6ca4b16caca75a3b2a749c31fe6301ee09f6ad6b5ff46ef9146d9238ec98386a10012b147ab2474e551a1b252baf2e79a",
+        "dest": "081_readr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/reshape_0.8.8.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/reshape_0.8.8.tar.gz",
         "sha512": "f8924fcfa10fb4f60c594c629b020dbc61c166aecf7e8e2c2d2c88d4a230503b43f06f4bd9df40475c533bbb11b1dbe62dfe95db76e65fd15314dfbe182062e9",
-        "dest": "091_reshape.Rpkg"
+        "dest": "082_reshape.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/reshape2_1.4.4.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/reshape2_1.4.4.tar.gz",
         "sha512": "7378ca67e076100014df8a35cfd89e828387f3b09c0f546daf5f1532865dad227eb0adb849a8195ce536c91f04c64b2f875ac18c755b7b77f2ebe23dd9fbf545",
-        "dest": "092_reshape2.Rpkg"
+        "dest": "083_reshape2.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rpf_1.0.4.tar.gz",
-        "sha512": "a46358fcdb9f91fa1a57e0b8899fefc58b063e739fba06ea8c07c970e164ec70a30a03d8efb7963d93f0bbf76f42ebf8ea171f21fdb2a07635e718a5147479c5",
-        "dest": "093_rpf.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rpf_1.0.5.tar.gz",
+        "sha512": "913aeb31d40e535d8f87923879fb2a4bf20b2b73a355ef034a7660974b3945bddc93226d9cdcaeae5e2725b14804663c5fc54f42c4201536f5a5451c92ac84bc",
+        "dest": "084_rpf.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/sandwich_2.5-1.tar.gz",
-        "sha512": "381a4f3f1252e61796744a0d15ce1a118e4a0d4d06325294617fee77e4080e37a0832794d03e1478b7a897058693a50a5c0e59591f445517590f7772c7fd7d04",
-        "dest": "094_sandwich.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/sandwich_3.0-0.tar.gz",
+        "sha512": "d3be49c2e83cb9af8d5cd129412611985e9c81803085ee38f8b59bb40014e4836d4844ed460ab1a6c2ffd5d4123b355209d8ba7117fff38d41c06d59ce48c7f8",
+        "dest": "085_sandwich.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tidyselect_1.1.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tidyselect_1.1.0.tar.gz",
         "sha512": "827bd7f3d3dd4a1397323bec2fa26b871afb9cbf082a9281c01d4f06f6020afc46ca0bc4968b7dd5d82033c8c53fc43866b1bc31b6084fd6715d0eab093480e8",
-        "dest": "095_tidyselect.Rpkg"
+        "dest": "086_tidyselect.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/viridis_0.5.1.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/viridis_0.5.1.tar.gz",
         "sha512": "73bc64b5d8dccc699e70e031dce7b33ccc60c192449aed49a0c0741c7e820a92c39e3ae4da7e787acb9839ad0fe0588aeb5bd976e9b42d3bf3ae4c79a7126ebd",
-        "dest": "096_viridis.Rpkg"
+        "dest": "087_viridis.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/BayesFactor_0.9.12-4.2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/BayesFactor_0.9.12-4.2.tar.gz",
         "sha512": "a6512e1f088f2ee85de7e6d6e4f35c618ff920f26b60b03aa62c0367f2b343138cfc46e41e7b4b8bdf78c725bbe51fab60a961d1123994687e0f3f6d41d243d9",
-        "dest": "097_BayesFactor.Rpkg"
+        "dest": "088_BayesFactor.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/GGally_2.0.0.tar.gz",
-        "sha512": "bef3855434bbc49f1dd966a23e1d405c0fb38dbe5d63c1bc805a9cfc486793d5367cc6a340101a92eca096fbeda08f1c25ec53107eaf8908ad61eeb17e6b589d",
-        "dest": "098_GGally.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Hmisc_4.5-0.tar.gz",
+        "sha512": "a43a97e053b00d58d24ad673d6d4d920f7f43956a8f30b8da5b0fce5fad6e565473eca2c8e3def865e30b7d5ed14e3aa3a6f559ed634a80919cf69048e29b17b",
+        "dest": "089_Hmisc.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/Hmisc_4.4-1.tar.gz",
-        "sha512": "b2d3f90be6c7a59fe895deb08c2d3bfaa0e13e6d8acc7a11e622917f2288904f51504bbbe818cdf14b6cc8f2b75adf36dd8bcb50b71657c180a15050a97d6c6f",
-        "dest": "099_Hmisc.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/OpenMx_2.19.1.tar.gz",
+        "sha512": "e35a032dbd88b38039cac39ac47c535f222461dab7c11634d94b0ab30bf2743719c89ac9c281f857915207c788fa213f080f8c139c6ef44f3e82c3223efe811f",
+        "dest": "090_OpenMx.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/OpenMx_2.17.4.tar.gz",
-        "sha512": "845d52b1ce6219392808099fd6527c74202bea34b87014033d64e0f847c043e161039be00a1c61404da0418cb1c9a6a2eb1646083ad83b0e2849a00450c256c7",
-        "dest": "100_OpenMx.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/dplyr_1.0.2.tar.gz",
-        "sha512": "b0518fc6dd00dfa713ca08d207fd151b3de66486911296cf7dd0a5f40b26abc419f90c5748ecda8b7aad9c88372956cbbd1c6517510d6a4e89526054a50a2493",
-        "dest": "101_dplyr.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/exact2x2_1.6.5.tar.gz",
-        "sha512": "f78bd98209790272e765a3dd18844e3cfa903fb47440f125e614c2ac4b3792d2fd3938837e39f22f5eac7a934b6cdc28573085893ffcd8e132f9c9a20581752c",
-        "dest": "102_exact2x2.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ggforce_0.3.2.tar.gz",
-        "sha512": "783be2745a1eee549103f7ecdc48caed2efc080842b956b38d98360b7eddde6a15266a7de6ac57de98497540ad1b6505ace3a90e1379d3faac1bbf0ecd363dc4",
-        "dest": "103_ggforce.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/gplots_3.0.4.tar.gz",
-        "sha512": "a92ac45d2b28603a6646c0a9e4244ba457a3e544424f77c02a2256020486460c7ea4c1f1062ec37a15af721f7e46c31cac8fa978d75cd4b268d2d5e590b368d5",
-        "dest": "104_gplots.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/haven_2.3.1.tar.gz",
-        "sha512": "0b705c8f5c04ee26b51938c96f6a2929ed2b2c9575606e8268a391a1e77b8372d8157065fb67971d4f6b560dbca96f546c43f8c82bdbd3ac12b82fee7c9dbcc1",
-        "dest": "105_haven.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/lmerTest_3.1-2.tar.gz",
-        "sha512": "41ead00aedfd81ce746ebeb83204f0ffb87be4baad11b0af16ae42b647c177ece9342cd4724702bb45ca4ced1512a77152f83f23d44f6022f90d0456f239257b",
-        "dest": "106_lmerTest.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/multcomp_1.4-13.tar.gz",
-        "sha512": "afb2262afd93b3ee0265d49f1668fcf33010f428162ec74aecc43dc21ef5794d1147216e2a34e960ba4d67a20706126cbf437f3a4cc895e7e25490510a2481d1",
-        "dest": "107_multcomp.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/pbkrtest_0.4-8.6.tar.gz",
-        "sha512": "433781c82dff9a5530d42ddd500d2dd09783e3b5efe51deb21fcae0ec4aa61510782c895b695ba9e02646eb72efaa88ddf256590eb2d6a3f26f145867bf86b51",
-        "dest": "108_pbkrtest.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/quantreg_5.61.tar.gz",
-        "sha512": "81e8d3dc36279e643c6c55139879d98733ab05589a1cc326493643ee5341dd57a0c58621fb1a0559b158b21bb841ac7072504a12e7021be4e79ba82267fe052b",
-        "dest": "109_quantreg.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/readxl_1.3.1.tar.gz",
-        "sha512": "befeb57b4b5eeb934e08927aca0c0026591d264c34a029f2d77509b60d466c7f8e5df7d11bd38865ab1010042eb30f93363bf0c6fce608ae724f1ccb0b402ac2",
-        "dest": "110_readxl.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/regsem_1.5.2.tar.gz",
-        "sha512": "b725f728102ee7b33300455567aa2e0f9f60afe50172e5a5b766f4ff6634c857eaab543196e7a26d900e183f68983077c04218ee3028d75e3815bc6efce6a488",
-        "dest": "111_regsem.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rockchalk_1.8.144.tar.gz",
-        "sha512": "c08cb47474726f7f8b075c20ebb653ea5a4a95f4e5ea031c86a97acd46ef2a8040b459496ef0016ab5f3938e2e77cd342262ba6d4d75771a600b8063e6a75604",
-        "dest": "112_rockchalk.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/vcd_1.4-7.tar.gz",
-        "sha512": "803df23d9de711d6d7307f5f126b2572f6c32427506567554c2ac7226b9423c7eb500bad55fb6973d60ecd501576246efb5d6d7f66d7a8959a5384de8daa19b9",
-        "dest": "113_vcd.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ROCR_1.0-11.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ROCR_1.0-11.tar.gz",
         "sha512": "890ec81c3e6cf35c95ceed4a6ca1ee11ca64c28c200b52243d612ae3dbea03b764065f9779446fa0cb590366ed856e81fe1937d02793bcd9247a1e0ac07e0f8b",
-        "dest": "114_ROCR.Rpkg"
+        "dest": "091_ROCR.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/arm_1.11-2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/dplyr_1.0.5.tar.gz",
+        "sha512": "13e505b73d7e9dc5664154d483fd677e4bc245123685a3817d64646e78eb2ccef9cc1080f23ba7d9dd7a58ee59c025e9ab449d48c095717f662c1adcc49a4282",
+        "dest": "092_dplyr.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/exact2x2_1.6.5.tar.gz",
+        "sha512": "f78bd98209790272e765a3dd18844e3cfa903fb47440f125e614c2ac4b3792d2fd3938837e39f22f5eac7a934b6cdc28573085893ffcd8e132f9c9a20581752c",
+        "dest": "093_exact2x2.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/haven_2.3.1.tar.gz",
+        "sha512": "0b705c8f5c04ee26b51938c96f6a2929ed2b2c9575606e8268a391a1e77b8372d8157065fb67971d4f6b560dbca96f546c43f8c82bdbd3ac12b82fee7c9dbcc1",
+        "dest": "094_haven.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lmerTest_3.1-3.tar.gz",
+        "sha512": "44aa597cddd13d30cd56a8ffff8c70df6d325bdb03da219c943767728f0f7f335f88e39413d5e299d6b9e7da06991fd0ccf1e5c1d383c7fdbc54da338d961b02",
+        "dest": "095_lmerTest.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/multcomp_1.4-16.tar.gz",
+        "sha512": "bd565618507b66333b4b17eba4e4c852b81252e3d7e00927742f9d4f1cc7c3c075a15e1a8d0c243c7983707693a8dbf56a2bef28516c50ef3c2800725d554d08",
+        "dest": "096_multcomp.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/quantreg_5.85.tar.gz",
+        "sha512": "84ac54a169f8e5e62a100ce4e1818a3215febb12b26f0c767e8fcb2559c19ea32112a34b8eb19c4ba7cc0c844c609ea37c4f5632f8c2cf209994dd4423299e97",
+        "dest": "097_quantreg.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/readxl_1.3.1.tar.gz",
+        "sha512": "befeb57b4b5eeb934e08927aca0c0026591d264c34a029f2d77509b60d466c7f8e5df7d11bd38865ab1010042eb30f93363bf0c6fce608ae724f1ccb0b402ac2",
+        "dest": "098_readxl.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/regsem_1.6.2.tar.gz",
+        "sha512": "3e071516ff2b6516670a3a9ce9f50dff60d5d47de20b6983e5bdc07fa49c3120812ba69b801ad7439b0073bd1d84ce11cd34e8ec4031dc2bb92aa45e41edac23",
+        "dest": "099_regsem.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rockchalk_1.8.144.tar.gz",
+        "sha512": "c08cb47474726f7f8b075c20ebb653ea5a4a95f4e5ea031c86a97acd46ef2a8040b459496ef0016ab5f3938e2e77cd342262ba6d4d75771a600b8063e6a75604",
+        "dest": "100_rockchalk.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/vcd_1.4-8.tar.gz",
+        "sha512": "4d66f5ed9171ab0b3b68b4a772b820366e1409dc054769e949c14f092e4e8755dc7ce4553f5916beb87e72a95f543e425f98a8e30be73058d47b9d9d5e7755b5",
+        "dest": "101_vcd.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/arm_1.11-2.tar.gz",
         "sha512": "d26b98f476ddff5a51b9ae86033ab95a63dc31755bac853ad18a960040746ae27651242b2cac1a68fadf048c4aaf7186f63989381445674a43c5724d9a737116",
-        "dest": "115_arm.Rpkg"
+        "dest": "102_arm.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/rio_0.5.16.tar.gz",
-        "sha512": "96b789b6b896f29a91967bf10a876d47fa0cf901c62d0cc372ce78934194ee5b21ce432a113f8a194b20a2a28ca6d62e5725bd37d632be0f6827785e0cede965",
-        "dest": "116_rio.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/qgraph_1.6.9.tar.gz",
+        "sha512": "3e2c674e8fca975e805b007de3375e4e26c9f8f3657642cc77e5e0c916e801e14e3cea58430e02cc1d73014ddec21173cfa333331e31b50530cd194d1d6c8eb2",
+        "dest": "103_qgraph.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tidyr_1.1.1.tar.gz",
-        "sha512": "097f5f19b383abfe43c827c4ec2035c26831a5b3d845b7150f93a0bca922a57468df698fd8d4397eb648006812af06a7b32aca7400dd5b524f1a565eb4487882",
-        "dest": "117_tidyr.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rio_0.5.26.tar.gz",
+        "sha512": "413c78abafedb3fd6012e1534b0cb1f9b875c90a7a695dfbf94b3758d594059d03d1d2326da02c65715f5a31ec6c3e3bd8b51be2c64811fd62e0b6fe470798ca",
+        "dest": "104_rio.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/vcdExtra_0.7-1.tar.gz",
-        "sha512": "6add87a3c3f79b52643719554e120b02c505789fd39d794700ae81a0f5ade6cf5cb806528cb3096d20a794deb05e620f188efd0d08e44ca187a45ad3d61b6d79",
-        "dest": "118_vcdExtra.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tidyr_1.1.3.tar.gz",
+        "sha512": "e506126251ff53c2e9c5101c4ad47f4f160a8d4e5e43384d7934b733830c80e329bd0850fdfc13de47cf9fde2efcdb80e631e3042011b0510a0fb91fe7c89da5",
+        "dest": "105_tidyr.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/car_3.0-9.tar.gz",
-        "sha512": "6a0ece87fd84fdd0ccf6a13c10cc9f435c7423774602ca14c5e27889108e9c28110e9fd449017d7c014ce2dd7530a89fed7c5672c65618de72aef5c204c348d7",
-        "dest": "119_car.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/vcdExtra_0.7-5.tar.gz",
+        "sha512": "777a94108639546f5654aa3a214b3c9f9d1e2bdcfea00e4541fd03450b514484b59ed37032e1bc529c1f8bee59673823473505e5a129113202b6dbd9af533a0d",
+        "dest": "106_vcdExtra.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/mi_1.0.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/GGally_2.1.1.tar.gz",
+        "sha512": "c38661be10a9f5f27fffdfd412bb597e666949cfa0f5cb4d329005824356fce789832554c355c3971631513a46d48bf01cef9872281fb3d8930b4487c7488b08",
+        "dest": "107_GGally.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/broom_0.7.5.tar.gz",
+        "sha512": "07f24bafeb4d023e0005a9e9bb3b95f84a0c2153747c169cec2768737fc5510007c33baab833bb5b02c2620cbc3d6e16d9a13432057e8c1bbffe9ec280d983f9",
+        "dest": "108_broom.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mi_1.0.tar.gz",
         "sha512": "41295140031bfa478e56ae4abc529e1e499a4c7264c560d2a55142d7ca11057fc82d4e248a8317ca4777cf2dbeb55028fbfc25c9c758e82aefe5d7a0299d90c0",
-        "dest": "120_mi.Rpkg"
+        "dest": "109_mi.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/tidygraph_1.2.0.tar.gz",
-        "sha512": "31bae9ccaa59a0e367f614110baa6aee1dad760064f300e908ab2a1bcb36016c7879161278923509ffe443a25e5eb8f4371794fa3026882d8b30697009451f70",
-        "dest": "121_tidygraph.Rpkg"
-    },
-    {
-        "type": "git",
-        "url": "https://github.com/singmann/afex.git",
-        "commit": "fdfe4f5e96efeeac0ed6b78684f2da75c7c4d760",
-        "dest": "122_afex.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pbkrtest_0.5.1.tar.gz",
+        "sha512": "b13cbcb3740be0a86510eb3ce933a54f6ef3fcf225f8203099c50de75c88b473a0367a5215aaf3c18566e07835d75dbd5a1be514ff5bed6e3c39293c50c6cce7",
+        "dest": "110_pbkrtest.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/ggraph_2.0.3.tar.gz",
-        "sha512": "027609050f99872cd7b3e3a52fe7479a2590b386023f49c70dedc1a2ee502e1c00d610a3015cbc290104840a6c12ed9ac5eedfa0b66c2ff152b7b41ae201bed3",
-        "dest": "123_ggraph.Rpkg"
-    },
-    {
-        "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/sem_3.1-11.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/sem_3.1-11.tar.gz",
         "sha512": "adb2372a4a076085627b5bc0070e47d70080cb8ffbe1f2944ea76cb481db5e1200350aae0e8600924513e6353864dae25a10ca3f6e82e0db6bae38bf1feee64d",
-        "dest": "124_sem.Rpkg"
+        "dest": "111_sem.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/qgraph_1.6.5.tar.gz",
-        "sha512": "f11c6a1d20256211fe622ee1e2f7f16ae56972eb780a712cc11b2224e154b4d15bbf79aa1acde0b0dc6c081205f6c15689fee17a334a40fe6744e05823c37627",
-        "dest": "125_qgraph.Rpkg"
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/car_3.0-10.tar.gz",
+        "sha512": "59e7f58e5f79c854402f15049ed1e36a8e62a1fd3279a3a27194619a61f8120826207290416695767672e7d962190c4a0676cb4f41edb8cf47e1e88fd78118e2",
+        "dest": "112_car.Rpkg"
     },
     {
         "type": "archive",
-        "url": "https://cran.microsoft.com/snapshot/2020-08-24/src/contrib/semPlot_1.1.2.tar.gz",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/semPlot_1.1.2.tar.gz",
         "sha512": "ad44b5bf945b73c5302e845866e01daad1748a76d5f55507f25be476df12389de038ed23f369ffb7d4c33cfbad8659cf7491e61d1099e97125e3eac0b6229651",
-        "dest": "126_semPlot.Rpkg"
+        "dest": "113_semPlot.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/afex_0.28-1.tar.gz",
+        "sha512": "3de6df667259e883b00a328a12dc74430ff764c18250c2eec4cd6ae9042ce93a1054a68b905e9d34419d11cd76471bcbded4ff609711f6b5a6dcbbe67bdc735a",
+        "dest": "114_afex.Rpkg"
     }
 ]

--- a/jmv-deps-sources.json
+++ b/jmv-deps-sources.json
@@ -3,690 +3,690 @@
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/BH_1.75.0-0.tar.gz",
         "sha512": "03521484256e870d92f8e003b53b2c9f3ea28522c2b30a2465262cfec38becaf7c4ad5f4c72c11903e2189c6440850a81d2fd37c05708d284ee099d998759d77",
-        "dest": "000_BH.Rpkg"
+        "dest": "000_BH.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/GPArotation_2014.11-1.tar.gz",
         "sha512": "98e7506d4e7900a64273b1ad22da07a03990733ae5127c88e46ac5a01792bf3628c8147416a63d3a06237434c429853dcb87a8f65d50bcb7f449c294409dac5b",
-        "dest": "001_GPArotation.Rpkg"
+        "dest": "001_GPArotation.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RcppParallel_5.0.3.tar.gz",
         "sha512": "75594ca9d4e71aca37d736177f5c8732cfcd7d1ad6cdf7d99b27d1405088171d2e4bf0c0f9cc54180ce2c8376817fe9f5ef7825569fb684ac420a1b0f3dcba71",
-        "dest": "002_RcppParallel.Rpkg"
+        "dest": "002_RcppParallel.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/backports_1.2.1.tar.gz",
         "sha512": "ec0813fa1a7d99a4848ffe3cd8a44453931df7a321505f6689f1211465ef86847b1359d657406a6086b2ca113ae4d1f136c945e43467d0ed303ecf96fb5e436b",
-        "dest": "003_backports.Rpkg"
+        "dest": "003_backports.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ca_0.71.1.tar.gz",
         "sha512": "65dcc058150f4990854c0059cd812dc1561e9b79195481b56a621005e8cb55d8afaf8cdeabf7d2142043e50f2f8352d1609c9493bee0b86d71cb06c875e16067",
-        "dest": "004_ca.Rpkg"
+        "dest": "004_ca.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/carData_3.0-4.tar.gz",
         "sha512": "071108df88a0d76ae10f9a0c01801222e6899c82ad8e42c3832ae6a5629ac61d3fa77e7c6c3339260280de1114da7c4e1c9862c2a001da22748e4670c39e0287",
-        "dest": "005_carData.Rpkg"
+        "dest": "005_carData.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/contfrac_1.1-12.tar.gz",
         "sha512": "fa22fa5404c5917e8b33f1d5b4c7af8cf7a66212840b2d9cfed40230a0f74eb4ba0f9966248291ab08d6ecf7e94ac5b8a544e16297a6a30426a95d88f72833b7",
-        "dest": "006_contfrac.Rpkg"
+        "dest": "006_contfrac.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/glasso_1.11.tar.gz",
         "sha512": "eb82ccd8598900fc696b9e6f0d4d14d2b2e02c61786889b4aa3eaada85325afd7d136be2dc7767d9e380b30174ee5b259c004dd2606ad448f177b245597697fe",
-        "dest": "007_glasso.Rpkg"
+        "dest": "007_glasso.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/jpeg_0.1-8.1.tar.gz",
         "sha512": "f7e3148a54a4414505e3e3066b39634877ee9a69820df3e83e3593e78a6fd4d5047a5bd7abce8558149cd1e6519a13dec6d2b8412da8b396a73f3b661d2fba31",
-        "dest": "008_jpeg.Rpkg"
+        "dest": "008_jpeg.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lisrelToR_0.1.4.tar.gz",
         "sha512": "3ca8fc6405484d9b7c09df985caac3158c8e7c1b16526a46eda970e1b68acbe9ce278f825b0bb13b665dc7ad6d012ef0cd393c21de499022a9b6f874857e64ee",
-        "dest": "009_lisrelToR.Rpkg"
+        "dest": "009_lisrelToR.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/matrixStats_0.58.0.tar.gz",
         "sha512": "5f57a8a530619572f3c94eb9c4b997d3aef62a3932c6ff933423a6498407999dfdad9d8608b1594e6b173acc490925f9c4267df9add7083c5613a912353530c7",
-        "dest": "010_matrixStats.Rpkg"
+        "dest": "010_matrixStats.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/matrixcalc_1.0-3.tar.gz",
         "sha512": "ce7a5e026c951a45c9c8d305515457241d48ab53681167d684c32f3303492661c364afe8388c8ffb6716830c55ded9fa591ab06527e5bf0c31943491ed8f5b14",
-        "dest": "011_matrixcalc.Rpkg"
+        "dest": "011_matrixcalc.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/nloptr_1.2.2.2.tar.gz",
         "sha512": "fc553ab44f30d0d67be7a1a6cb67e24a90b74943505b3331e7f8f474bfa58a4655b23137c88d350472d4b7ffcb34503ba7ae81692948c4943600a2793e33ccc7",
-        "dest": "012_nloptr.Rpkg"
+        "dest": "012_nloptr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/numDeriv_2016.8-1.1.tar.gz",
         "sha512": "20e9dda1af54ff581f4f9218c34af204de5b78bb21eed88aef836ea215c37d90f7af8f1d972436316eab80451f531e1c9badb34f33001e3441a583a3ac4776e0",
-        "dest": "013_numDeriv.Rpkg"
+        "dest": "013_numDeriv.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pbivnorm_0.6.0.tar.gz",
         "sha512": "44d6a3edc899533d392009034037b8221e5c94ad570a4d91789c0c23971f4385a4f317651733c92366146fea75db9f84fd33bebf8c56e90ea6e4139fd924bde2",
-        "dest": "014_pbivnorm.Rpkg"
+        "dest": "014_pbivnorm.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/png_0.1-7.tar.gz",
         "sha512": "033a2a45e0fc55a9975257397162ceac0416afb47bbf266025e1ed00790ea1261d1254255aa09cd8828e034b0cd8006cc5e26c9f732ec996dcbec3c937e00f5f",
-        "dest": "015_png.Rpkg"
+        "dest": "015_png.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/qvcalc_1.0.2.tar.gz",
         "sha512": "a3db18c43ab9d2eca6e604f465aaa27a56a04b46e51f75b032ceab5f2e1d94829bb02257c9dbecbf1e9a281ca28ff98e1571262fa6c98960268e9c3cb97b9b4b",
-        "dest": "016_qvcalc.Rpkg"
+        "dest": "016_qvcalc.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rematch_1.0.1.tar.gz",
         "sha512": "b97c4d8c4d8fd3706e8d1f97eb1ea21fb3cd45289933bf4559b5131b6cfae37434a7fae5f2bd07acc8bb3b9e40874bd893b7a5e5bc63d6a4dcf624a5d51f0ab1",
-        "dest": "017_rematch.Rpkg"
+        "dest": "017_rematch.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tmvnsim_1.0-2.tar.gz",
         "sha512": "c70ac65ad1e3e632d4a3ed5d2a72ecb20c9b303263eb5ee0b2f6cc74762155c28e359579e202e8fda373a1effd280bf640dbe603e4520104fe84039cf333aced",
-        "dest": "018_tmvnsim.Rpkg"
+        "dest": "018_tmvnsim.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/truncnorm_1.0-8.tar.gz",
         "sha512": "e45a59be9b35a95bfdd7bf9a29d72e9483969a3c327107b9e338dcc9c58db38949dbdcc8f4d4ee64ee861e4eab6690e14601a3ccc197dce0ba6b93ac4c73ae23",
-        "dest": "019_truncnorm.Rpkg"
+        "dest": "019_truncnorm.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/zip_2.1.1.tar.gz",
         "sha512": "17831001fc767154425b19a230e07cbe50797fe3e767a680da70daa5c49634f48f2731f0260bc54c18a41219d8a30f3df5f10246435793ad183638794b025a24",
-        "dest": "020_zip.Rpkg"
+        "dest": "020_zip.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Formula_1.2-4.tar.gz",
         "sha512": "9fa7bf9710c37ae28454b533dfe82cc602b0ddae4ecae38e31155cd957cba51060ba84fa0bbc3adf65aa02d0a2c56fea3a852da292bb71d615437fbdc246a741",
-        "dest": "021_Formula.Rpkg"
+        "dest": "021_Formula.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/MatrixModels_0.5-0.tar.gz",
         "sha512": "4804ad8dfb596697ecfd37ab013d7c05e8e99716ed2ed7a87180ad45e2acad21bce9e5742e6d812582b399155c33d9e29e2610f9ec98c56d9229c51ca9a44339",
-        "dest": "022_MatrixModels.Rpkg"
+        "dest": "022_MatrixModels.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/PMCMR_4.3.tar.gz",
         "sha512": "56d9785468f3c6c6abc0038ee019bf93ea48dd29c42b74d03f3d11971a9695072f41b5b20c65dc361acfdb4c57e6eb39d7191ab23f46a5cdbfc5d90c89fdd6a3",
-        "dest": "023_PMCMR.Rpkg"
+        "dest": "023_PMCMR.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RUnit_0.4.32.tar.gz",
         "sha512": "5df78b0b653cb122e8edd23fc95e00966c5e54ee5db081efb216e88847d8e292fb69af27932a35f5d51ebaf3a162128fd4a604b8d1e2dc8dfb6a8a72345432e7",
-        "dest": "024_RUnit.Rpkg"
+        "dest": "024_RUnit.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RcppArmadillo_0.10.2.2.0.tar.gz",
         "sha512": "b068fae82278165d36756658fc3813302ad253bddc3d869034ab0fb81519596ca396e56bb35fe8cae372ff2d4557b55a52522698fcd6c2f30867c1f1b557b662",
-        "dest": "025_RcppArmadillo.Rpkg"
+        "dest": "025_RcppArmadillo.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/RcppEigen_0.3.3.9.1.tar.gz",
         "sha512": "9e5d88c31d49c9dc3054c794313b1c9796e2b9538b667227631c5449670531cb1c7adb42a27701e3fd1939c889e7da742fd7aa56e20bf54445b4295c92d90eae",
-        "dest": "026_RcppEigen.Rpkg"
+        "dest": "026_RcppEigen.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Rsolnp_1.16.tar.gz",
         "sha512": "d58becf1b89794f9170246758d786547e1fa475aba1d64e681bbde8d5bf6a9ed507589877095adc3584139b8085f7107245f1ec1737d10ee7d314222f47d11b8",
-        "dest": "027_Rsolnp.Rpkg"
+        "dest": "027_Rsolnp.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/SparseM_1.81.tar.gz",
         "sha512": "3fba6796a48a32059e9b7a7a22302c251a57abaca3c8a90dd531a9f7d201cb1156b65382b00b3d9e4dc919031d7adbe9c7744304401974c81063ef23d98fe126",
-        "dest": "028_SparseM.Rpkg"
+        "dest": "028_SparseM.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/TH.data_1.0-10.tar.gz",
         "sha512": "adf4900e88f33cece07088a9bf64c57fb7cfe850f287a531d5690d67c68922c71855efc0d591e58f1167ee619b23d9cd730656bec5c54bf9f9883cfe1dc4dbbb",
-        "dest": "029_TH.data.Rpkg"
+        "dest": "029_TH.data.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/XML_3.99-0.6.tar.gz",
         "sha512": "ad18cd2eb0e857e5b7f53a3db5729cb4be4f4a98b3b84b97108595497f85363858910a0d3e0a3134776cd978da75abf2bf00854a99bef797d88e9f80a081c5af",
-        "dest": "030_XML.Rpkg"
+        "dest": "030_XML.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/abind_1.4-5.tar.gz",
         "sha512": "b1f5d716e04f748b9d189a4a3e15ad00c2b5a7c69425dbf9f36fcb4fe23f6ff5cec2eb22ec626ab194c1eb88bdfd271b535868b00157efd4acf0faa022d16987",
-        "dest": "031_abind.Rpkg"
+        "dest": "031_abind.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/caTools_1.18.2.tar.gz",
         "sha512": "79f34877a58322857da2595eb977ba047ee97dc25420921ce1a29b5060bc2082f38bc2ec4afd0f3243bc1991c86353e0d12cbf593ad5241623a4abae8b023058",
-        "dest": "032_caTools.Rpkg"
+        "dest": "032_caTools.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/cellranger_1.1.0.tar.gz",
         "sha512": "5a27ce21b5d22b0eea06f64ef6faf26a63860ccefa17e3d4cb74ffceaf8b0b6f332b482d476dbc32f8174d5bfef01a5f9fc20673db2fa5386682be1baf11d2a9",
-        "dest": "033_cellranger.Rpkg"
+        "dest": "033_cellranger.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/checkmate_2.0.0.tar.gz",
         "sha512": "8d575d79744157d21e0e6492f9107ede62f21bc2ba6c372853bf0f19b191f4bab01397f015f99384e331bcf1a300215a541528c0d60a49dca05144332af51077",
-        "dest": "034_checkmate.Rpkg"
+        "dest": "034_checkmate.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/clipr_0.7.1.tar.gz",
         "sha512": "1c57770f3c765b2ebf8be7146dc7688476900368a4845506cbd21d981e33f53093bce9178c76698f4fc8eed1b3fd086ac4ad4dc63a4682520bb97e49e4ea0839",
-        "dest": "035_clipr.Rpkg"
+        "dest": "035_clipr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/coda_0.19-4.tar.gz",
         "sha512": "f390a76658fc49da236dfbf04c920a9cf148ee6ecbb4ca595b6c5a20e8d87a749e67fe294ce63781a277b51b31741508197f9939b62b1edda03228022a02c950",
-        "dest": "036_coda.Rpkg"
+        "dest": "036_coda.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/corpcor_1.6.9.tar.gz",
         "sha512": "8e80794336b6526564c0ecefaa17c3a063d8a5913cd0dc1fc3fbde65d50821cadb097031607bc129be0e742d2ba9181e9027d0b692477cfa299b6e569af4908a",
-        "dest": "037_corpcor.Rpkg"
+        "dest": "037_corpcor.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/data.table_1.14.0.tar.gz",
         "sha512": "db90998904270f42cc654faa0b333f8e720e4044c7f2c82f52efbb69e1ed30c5b2c1b034f7a5baff4543151eda7fb33aa454817889ac95a5d17d6aba364396df",
-        "dest": "038_data.table.Rpkg"
+        "dest": "038_data.table.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/deSolve_1.28.tar.gz",
         "sha512": "85dc2ef3439edbf4406d78b469be1c94a087b55ca595960bcc00653984d927d1bf26670a46c73656bfdb6cae2ef6e1741e97cbfb690fdbf1040cc3f69cf157c4",
-        "dest": "039_deSolve.Rpkg"
+        "dest": "039_deSolve.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/elliptic_1.4-0.tar.gz",
         "sha512": "6569ee1695673c171822007661c928dd1e7493aa5c64463477bfb5d354027f3181d174c217b5794ee9efafd8078ec8dc89bc9aded912d81d1c0e4207f9a3b2f3",
-        "dest": "040_elliptic.Rpkg"
+        "dest": "040_elliptic.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/estimability_1.3.tar.gz",
         "sha512": "83f707dff5f85eebdb9560314a1e4717a17c97a4517ef774b9a6070bbabe63f0940c87c8b1aa1e5b750a5ca8ecae09e051c57579217284c1f4ca005ce323c952",
-        "dest": "041_estimability.Rpkg"
+        "dest": "041_estimability.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/fdrtool_1.2.16.tar.gz",
         "sha512": "bd9da5eb9c5345fa523f828660e365cc5bd70a7d637c3149acd3dc3fdc76942e5962aae8cf93ae145f74e4af1e99aa576ed50ded9c96897c7e5a328094d3afd4",
-        "dest": "042_fdrtool.Rpkg"
+        "dest": "042_fdrtool.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/forcats_0.5.1.tar.gz",
         "sha512": "44b3e90e764afe4a2a7339e72a8c01c053ba972611a194d7d278a4bb7c4959b0a514a0ac1f2c41a82219060e699e961b079c1edceac52fa1d42e53e7c2d15b97",
-        "dest": "043_forcats.Rpkg"
+        "dest": "043_forcats.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/generics_0.1.0.tar.gz",
         "sha512": "fc96efafe114a66eee57aba48b7ab763204c1bb43570eeda742bca9e7486b47a0bf01bad87f2bf225a5c67f0abaf60c758afe7dada049b692ee864077334616b",
-        "dest": "044_generics.Rpkg"
+        "dest": "044_generics.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gridExtra_2.3.tar.gz",
         "sha512": "916b5d64bd17295855d4c81b628e900cb16b3eb3b7b0f25ee00a91bfbaf480a0785797508c4671031bc3f2a71a32fa3ecc828420fc33b3139d7e46b3bfefca68",
-        "dest": "045_gridExtra.Rpkg"
+        "dest": "045_gridExtra.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gtools_3.8.2.tar.gz",
         "sha512": "08e3a6548a5078a241e8cf335d2bbb5ea8d09e6ce4865dbb84699faf2c96ad00534263d737c9f818c602b108009390bee3a86b5671f04d1d9213201e8d7ab6d3",
-        "dest": "046_gtools.Rpkg"
+        "dest": "046_gtools.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/hms_1.0.0.tar.gz",
         "sha512": "3559bbb4e8780770f242ba53dcb5920fd164a7b9fb3f6e379acb9534444f544ad59fdd33eea13194849787f16f418fb8be39239f030fba9026e5ac2184d0713d",
-        "dest": "047_hms.Rpkg"
+        "dest": "047_hms.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/htmlwidgets_1.5.3.tar.gz",
         "sha512": "6f7551f92f7ac76c99044651c763eb51fb5f82bd0d03b890698e0a3fca80e2ee010cdf5c0940c6b8a4ebebf9861d3c343d3cd1ac1953b08011fb3cddd11a6b75",
-        "dest": "048_htmlwidgets.Rpkg"
+        "dest": "048_htmlwidgets.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/igraph_1.2.6.tar.gz",
         "sha512": "1acefb09abeaf904c5934399b883edff200445ced6b7b5a3cf17041d67a128d3d656f6ad5ebe407ea3dc7277b7564db5fb21dd462ec15cd25ac5f9fe9adbe996",
-        "dest": "049_igraph.Rpkg"
+        "dest": "049_igraph.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/latticeExtra_0.6-29.tar.gz",
         "sha512": "f6730a33b852f336d67bb8f27b8b67e1622700e5f64e1f269355fff4034e928e191c9cdbc357c6fa6eb1eef44d34fdbe143f99531d272d993bc583764be7211e",
-        "dest": "050_latticeExtra.Rpkg"
+        "dest": "050_latticeExtra.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/minqa_1.2.4.tar.gz",
         "sha512": "1f21e661b6bb8bad5074d2ac579ec0fa031a149c52dc22bc5d73927bfc71ac9bfbf73b01730288f5f4a9930aca53e838e028772996b2860a4f5578a151f61967",
-        "dest": "051_minqa.Rpkg"
+        "dest": "051_minqa.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mnormt_2.0.2.tar.gz",
         "sha512": "36cc5547be970c6e04fdee4c0442e5d6851f4f0fe2f8234b708b54cdfa6487b67bfc1347d7d4e3eb20e823a27befa1b9da2c860eec10c29f230106ef851757b0",
-        "dest": "052_mnormt.Rpkg"
+        "dest": "052_mnormt.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mvnormtest_0.1-9.tar.gz",
         "sha512": "cef4d945feb7faeffd5e68fce116c4f9fcb03f5c601dddd47f88f9ddf297bee90c588587c2033c7b7c40d825c972303fb2f38077e8472b4d35e4bd92af1e6648",
-        "dest": "053_mvnormtest.Rpkg"
+        "dest": "053_mvnormtest.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mvtnorm_1.1-1.tar.gz",
         "sha512": "ae7e10f45594c31ae9fdd45cf011fbb82d4835a5ba971fcbac3d451773ba17f447bfaf2048c9a790d7404280eff820fc7b875ab38350a20445f781fc19158340",
-        "dest": "054_mvtnorm.Rpkg"
+        "dest": "054_mvtnorm.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/openxlsx_4.2.3.tar.gz",
         "sha512": "72027c4d2c4c6f4b4728c2a6edbd4bd75a15b2d46f99e5c41dfbd2109f2ab5f91bf72d21528ab72aa23c4b22a9370a63e07871125cc22a6192a70a993453b756",
-        "dest": "055_openxlsx.Rpkg"
+        "dest": "055_openxlsx.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pbapply_1.4-3.tar.gz",
         "sha512": "ac354dfdc672b556b1299ce54127db68cbc7fd3ff36e37bd5a58401261aa6e6039814a075a7bca612b49c0d4d249eec691e56ff800b85b323b4fe29d5650a75c",
-        "dest": "056_pbapply.Rpkg"
+        "dest": "056_pbapply.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/plyr_1.8.6.tar.gz",
         "sha512": "2c41e77b338055fbc500cf3c5e1f8b0e8339692eb18b63edceca92f4e4ba4b3930d718b59da79ab459230f4177de718a034069bbf42c1b0e47b97ba99dcacec7",
-        "dest": "057_plyr.Rpkg"
+        "dest": "057_plyr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/purrr_0.3.4.tar.gz",
         "sha512": "30f121c751e6c85b986b872ed1bae6464d2f0f3b79493537d4f1b673d55725218dd982a2ed7b8b8a12b2aad586db3133e49721812f35bf3b2c692612759bb2ca",
-        "dest": "058_purrr.Rpkg"
+        "dest": "058_purrr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/relimp_1.0-5.tar.gz",
         "sha512": "46a73aee8aedaadc4a703d9edf25079fa994b36cf696d15e5e7da270440a3ee244fff1a70bac2ff24bca813b0627a092d2626416bca9d7e967cd5cd529ceeccf",
-        "dest": "059_relimp.Rpkg"
+        "dest": "059_relimp.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/sp_1.4-5.tar.gz",
         "sha512": "c5773c369a6aedcd13b8da204f987914da21590dc7bb45eee29592ab68ffa0962790f1a8aa1f53126fcc35ee80bf0a29107cd7c31b6412eb27be5255c6ee2002",
-        "dest": "060_sp.Rpkg"
+        "dest": "060_sp.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ssanv_1.1.tar.gz",
         "sha512": "ccb43e466bb50a3816a609503811eaf59eafec405578356cd8fa5ef2bbc646aa23e28ace945a394ee7129f4aff87ca8cd7ebd946eacc71f23a0d8e9046894c64",
-        "dest": "061_ssanv.Rpkg"
+        "dest": "061_ssanv.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/statmod_1.4.35.tar.gz",
         "sha512": "0163a72488446477daf2132522cf04dac4fdf847df1b39dd708c888108917927a0509ce92c102142657a0a2121cbd6c12c3672f581bebc36611430abc6881217",
-        "dest": "062_statmod.Rpkg"
+        "dest": "062_statmod.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/xtable_1.8-4.tar.gz",
         "sha512": "0143e22d3fc60c30159387f1614ecb269bc90d8d7a32d10f7f1e7f77863dfe33a71ca95cb1abd7b3d0f889e26a63d16e60dea4a1d4a33bbcbe6b5c823ed96b09",
-        "dest": "063_xtable.Rpkg"
+        "dest": "063_xtable.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/zoo_1.8-9.tar.gz",
         "sha512": "c5516542fa8efc3c83d1dfaafded3f4f0f0bc32549c07f2512291951e2d783c39705bbb315437cd0a666db18b8d987f7b25d2ec958cbdb19b1a3270caf15e940",
-        "dest": "064_zoo.Rpkg"
+        "dest": "064_zoo.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/StanHeaders_2.21.0-7.tar.gz",
         "sha512": "474637f3043defb4b646b37b12469a7bc9df823f954e9b5cd788063e702527065da54cbfb5f3829c44912e07855f403f00962149277a8f7c5f694319b30a9556",
-        "dest": "065_StanHeaders.Rpkg"
+        "dest": "065_StanHeaders.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/conquer_1.0.2.tar.gz",
         "sha512": "835f6b89c6e1d28abba78aa3b8097e68e027035a6d609ca56ff54f32f2023b245e3882aada74d0a7dde915d1f444041dd850265e6d2970b0ce974db49007928c",
-        "dest": "066_conquer.Rpkg"
+        "dest": "066_conquer.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/emmeans_1.5.5-1.tar.gz",
         "sha512": "5b5809750d1fbc36f6798b182360abb1dcad52a12ff9890eaa687708c6bc1ed4846bbcf047357184b81736df24e6b26cfc1d6bdda4b27d24f5d8049ed24ca195",
-        "dest": "067_emmeans.Rpkg"
+        "dest": "067_emmeans.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/exactci_1.3-3.tar.gz",
         "sha512": "2f424fd7ba4871794b92f6487477cf7b8da857f4d25da34bd2be3a85289b4e54ac0431b909a602790afc05f7933085b50c4cdfb70fef7cd374626f28313ab67c",
-        "dest": "068_exactci.Rpkg"
+        "dest": "068_exactci.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ggridges_0.5.3.tar.gz",
         "sha512": "3f9518d3138d6e5b990e188d38203213c172efab2daeedb580f6253692097d378bd4ddf57b92930babb445862fbca259f0ee297b535da72ad9194c8d2748b484",
-        "dest": "069_ggridges.Rpkg"
+        "dest": "069_ggridges.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gnm_1.1-1.tar.gz",
         "sha512": "a753c9387530e32db749e69c794664213e9d38c61ced1ba5d0677bfa7f54a7d3df59abdc94810a14d59b89dd5473154de01fd8d7de7c164597c3a252353be053",
-        "dest": "070_gnm.Rpkg"
+        "dest": "070_gnm.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/gplots_3.1.1.tar.gz",
         "sha512": "bcd04d1369a05adec99a915d69eb2d419d987eb5bf4f78e1b2ab7b3406ed1139e830e6abad8b72952984c5f4ac51790bf016e7e79a18355816dede8101c73a6c",
-        "dest": "071_gplots.Rpkg"
+        "dest": "071_gplots.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/htmlTable_2.1.0.tar.gz",
         "sha512": "a9753832be81024c51993f36981b539aef57f1f044a1c5c6dcbf0d4a3b5ea615a63f6f1fa70f5690ae4286f6937c14929b33d3d3d4d00a8048c4e8b575a73f40",
-        "dest": "072_htmlTable.Rpkg"
+        "dest": "072_htmlTable.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/hypergeo_1.2-13.tar.gz",
         "sha512": "7e3c0b89bfb849325511a84df341711b513a8f2c7ff6ea40787e7253b0e5aa65a6cba396bef46a43047ff42bc2692f5fc8f258312eaeef384b246d845873296b",
-        "dest": "073_hypergeo.Rpkg"
+        "dest": "073_hypergeo.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/kutils_1.70.tar.gz",
         "sha512": "618fa364786cd23aee043266aedc089f1bec44d81b2a64d5f3e189fe8f601fbc07c513d96143e330e730ebcb10269a46e2c3187315e6575551804ea04b18d2c8",
-        "dest": "074_kutils.Rpkg"
+        "dest": "074_kutils.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lavaan_0.6-8.tar.gz",
         "sha512": "265ec8b05a7dbc91a040f2e4f8e3fa7691781a3e82be5e3b6fc93ef730797e7f5f91c22c4ef354e8274b4bfa3a5df185dc6d1f4f6e3d3e0d963f1ecb30912033",
-        "dest": "075_lavaan.Rpkg"
+        "dest": "075_lavaan.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lme4_1.1-26.tar.gz",
         "sha512": "e28d4b93fceb9ac3ba44ae8d8521ede9f9e3b4c7a079f6fbe306300846cb8589eba48dc401764c747072ca6a10a857c3a24a1b68c93db98927d5060ec81aa673",
-        "dest": "076_lme4.Rpkg"
+        "dest": "076_lme4.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lmtest_0.9-38.tar.gz",
         "sha512": "191ff072c8dde7b122f30d2025263348b3a8e742967e8442fd9dfdc89c1535466f8878d742ebb821c250ff5c219aaba5b6655d29abdca8e4cb7700ae6788917f",
-        "dest": "077_lmtest.Rpkg"
+        "dest": "077_lmtest.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/maptools_1.1-1.tar.gz",
         "sha512": "069530531e498c62bb363da20f799ab7d63db4400844cec376b166c70dedd9fdd4070b25918408a6f707298f355b9dc24ca0ddcedb7a9dec556b900c924fd32b",
-        "dest": "078_maptools.Rpkg"
+        "dest": "078_maptools.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/progress_1.2.2.tar.gz",
         "sha512": "c02dfd93f43ac82ea44b97e53dd9e570aa90e95c8e4a9088114bae77f573eaba536b167a27d6a6a48d6db1d0b21d59d22468b48c0ce9580862af35f7bb3ee0bb",
-        "dest": "079_progress.Rpkg"
+        "dest": "079_progress.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/psych_2.1.3.tar.gz",
         "sha512": "97b4c61c1f2e30e002f4998336553d72107fde9a0b7f590391dea1751d75479d9fa25a45e75cd59987bc0a1f91af4a29b035d300b0cd2a567bcb37a9b535dab5",
-        "dest": "080_psych.Rpkg"
+        "dest": "080_psych.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/readr_1.4.0.tar.gz",
         "sha512": "516059e44416c097ebfff6d138e7c4e6ca4b16caca75a3b2a749c31fe6301ee09f6ad6b5ff46ef9146d9238ec98386a10012b147ab2474e551a1b252baf2e79a",
-        "dest": "081_readr.Rpkg"
+        "dest": "081_readr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/reshape_0.8.8.tar.gz",
         "sha512": "f8924fcfa10fb4f60c594c629b020dbc61c166aecf7e8e2c2d2c88d4a230503b43f06f4bd9df40475c533bbb11b1dbe62dfe95db76e65fd15314dfbe182062e9",
-        "dest": "082_reshape.Rpkg"
+        "dest": "082_reshape.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/reshape2_1.4.4.tar.gz",
         "sha512": "7378ca67e076100014df8a35cfd89e828387f3b09c0f546daf5f1532865dad227eb0adb849a8195ce536c91f04c64b2f875ac18c755b7b77f2ebe23dd9fbf545",
-        "dest": "083_reshape2.Rpkg"
+        "dest": "083_reshape2.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rpf_1.0.5.tar.gz",
         "sha512": "913aeb31d40e535d8f87923879fb2a4bf20b2b73a355ef034a7660974b3945bddc93226d9cdcaeae5e2725b14804663c5fc54f42c4201536f5a5451c92ac84bc",
-        "dest": "084_rpf.Rpkg"
+        "dest": "084_rpf.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/sandwich_3.0-0.tar.gz",
         "sha512": "d3be49c2e83cb9af8d5cd129412611985e9c81803085ee38f8b59bb40014e4836d4844ed460ab1a6c2ffd5d4123b355209d8ba7117fff38d41c06d59ce48c7f8",
-        "dest": "085_sandwich.Rpkg"
+        "dest": "085_sandwich.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tidyselect_1.1.0.tar.gz",
         "sha512": "827bd7f3d3dd4a1397323bec2fa26b871afb9cbf082a9281c01d4f06f6020afc46ca0bc4968b7dd5d82033c8c53fc43866b1bc31b6084fd6715d0eab093480e8",
-        "dest": "086_tidyselect.Rpkg"
+        "dest": "086_tidyselect.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/viridis_0.5.1.tar.gz",
         "sha512": "73bc64b5d8dccc699e70e031dce7b33ccc60c192449aed49a0c0741c7e820a92c39e3ae4da7e787acb9839ad0fe0588aeb5bd976e9b42d3bf3ae4c79a7126ebd",
-        "dest": "087_viridis.Rpkg"
+        "dest": "087_viridis.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/BayesFactor_0.9.12-4.2.tar.gz",
         "sha512": "a6512e1f088f2ee85de7e6d6e4f35c618ff920f26b60b03aa62c0367f2b343138cfc46e41e7b4b8bdf78c725bbe51fab60a961d1123994687e0f3f6d41d243d9",
-        "dest": "088_BayesFactor.Rpkg"
+        "dest": "088_BayesFactor.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/Hmisc_4.5-0.tar.gz",
         "sha512": "a43a97e053b00d58d24ad673d6d4d920f7f43956a8f30b8da5b0fce5fad6e565473eca2c8e3def865e30b7d5ed14e3aa3a6f559ed634a80919cf69048e29b17b",
-        "dest": "089_Hmisc.Rpkg"
+        "dest": "089_Hmisc.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/OpenMx_2.19.1.tar.gz",
         "sha512": "e35a032dbd88b38039cac39ac47c535f222461dab7c11634d94b0ab30bf2743719c89ac9c281f857915207c788fa213f080f8c139c6ef44f3e82c3223efe811f",
-        "dest": "090_OpenMx.Rpkg"
+        "dest": "090_OpenMx.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ROCR_1.0-11.tar.gz",
         "sha512": "890ec81c3e6cf35c95ceed4a6ca1ee11ca64c28c200b52243d612ae3dbea03b764065f9779446fa0cb590366ed856e81fe1937d02793bcd9247a1e0ac07e0f8b",
-        "dest": "091_ROCR.Rpkg"
+        "dest": "091_ROCR.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/dplyr_1.0.5.tar.gz",
         "sha512": "13e505b73d7e9dc5664154d483fd677e4bc245123685a3817d64646e78eb2ccef9cc1080f23ba7d9dd7a58ee59c025e9ab449d48c095717f662c1adcc49a4282",
-        "dest": "092_dplyr.Rpkg"
+        "dest": "092_dplyr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/exact2x2_1.6.5.tar.gz",
         "sha512": "f78bd98209790272e765a3dd18844e3cfa903fb47440f125e614c2ac4b3792d2fd3938837e39f22f5eac7a934b6cdc28573085893ffcd8e132f9c9a20581752c",
-        "dest": "093_exact2x2.Rpkg"
+        "dest": "093_exact2x2.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/haven_2.3.1.tar.gz",
         "sha512": "0b705c8f5c04ee26b51938c96f6a2929ed2b2c9575606e8268a391a1e77b8372d8157065fb67971d4f6b560dbca96f546c43f8c82bdbd3ac12b82fee7c9dbcc1",
-        "dest": "094_haven.Rpkg"
+        "dest": "094_haven.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lmerTest_3.1-3.tar.gz",
         "sha512": "44aa597cddd13d30cd56a8ffff8c70df6d325bdb03da219c943767728f0f7f335f88e39413d5e299d6b9e7da06991fd0ccf1e5c1d383c7fdbc54da338d961b02",
-        "dest": "095_lmerTest.Rpkg"
+        "dest": "095_lmerTest.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/multcomp_1.4-16.tar.gz",
         "sha512": "bd565618507b66333b4b17eba4e4c852b81252e3d7e00927742f9d4f1cc7c3c075a15e1a8d0c243c7983707693a8dbf56a2bef28516c50ef3c2800725d554d08",
-        "dest": "096_multcomp.Rpkg"
+        "dest": "096_multcomp.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/quantreg_5.85.tar.gz",
         "sha512": "84ac54a169f8e5e62a100ce4e1818a3215febb12b26f0c767e8fcb2559c19ea32112a34b8eb19c4ba7cc0c844c609ea37c4f5632f8c2cf209994dd4423299e97",
-        "dest": "097_quantreg.Rpkg"
+        "dest": "097_quantreg.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/readxl_1.3.1.tar.gz",
         "sha512": "befeb57b4b5eeb934e08927aca0c0026591d264c34a029f2d77509b60d466c7f8e5df7d11bd38865ab1010042eb30f93363bf0c6fce608ae724f1ccb0b402ac2",
-        "dest": "098_readxl.Rpkg"
+        "dest": "098_readxl.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/regsem_1.6.2.tar.gz",
         "sha512": "3e071516ff2b6516670a3a9ce9f50dff60d5d47de20b6983e5bdc07fa49c3120812ba69b801ad7439b0073bd1d84ce11cd34e8ec4031dc2bb92aa45e41edac23",
-        "dest": "099_regsem.Rpkg"
+        "dest": "099_regsem.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rockchalk_1.8.144.tar.gz",
         "sha512": "c08cb47474726f7f8b075c20ebb653ea5a4a95f4e5ea031c86a97acd46ef2a8040b459496ef0016ab5f3938e2e77cd342262ba6d4d75771a600b8063e6a75604",
-        "dest": "100_rockchalk.Rpkg"
+        "dest": "100_rockchalk.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/vcd_1.4-8.tar.gz",
         "sha512": "4d66f5ed9171ab0b3b68b4a772b820366e1409dc054769e949c14f092e4e8755dc7ce4553f5916beb87e72a95f543e425f98a8e30be73058d47b9d9d5e7755b5",
-        "dest": "101_vcd.Rpkg"
+        "dest": "101_vcd.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/arm_1.11-2.tar.gz",
         "sha512": "d26b98f476ddff5a51b9ae86033ab95a63dc31755bac853ad18a960040746ae27651242b2cac1a68fadf048c4aaf7186f63989381445674a43c5724d9a737116",
-        "dest": "102_arm.Rpkg"
+        "dest": "102_arm.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/qgraph_1.6.9.tar.gz",
         "sha512": "3e2c674e8fca975e805b007de3375e4e26c9f8f3657642cc77e5e0c916e801e14e3cea58430e02cc1d73014ddec21173cfa333331e31b50530cd194d1d6c8eb2",
-        "dest": "103_qgraph.Rpkg"
+        "dest": "103_qgraph.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/rio_0.5.26.tar.gz",
         "sha512": "413c78abafedb3fd6012e1534b0cb1f9b875c90a7a695dfbf94b3758d594059d03d1d2326da02c65715f5a31ec6c3e3bd8b51be2c64811fd62e0b6fe470798ca",
-        "dest": "104_rio.Rpkg"
+        "dest": "104_rio.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/tidyr_1.1.3.tar.gz",
         "sha512": "e506126251ff53c2e9c5101c4ad47f4f160a8d4e5e43384d7934b733830c80e329bd0850fdfc13de47cf9fde2efcdb80e631e3042011b0510a0fb91fe7c89da5",
-        "dest": "105_tidyr.Rpkg"
+        "dest": "105_tidyr.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/vcdExtra_0.7-5.tar.gz",
         "sha512": "777a94108639546f5654aa3a214b3c9f9d1e2bdcfea00e4541fd03450b514484b59ed37032e1bc529c1f8bee59673823473505e5a129113202b6dbd9af533a0d",
-        "dest": "106_vcdExtra.Rpkg"
+        "dest": "106_vcdExtra.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/GGally_2.1.1.tar.gz",
         "sha512": "c38661be10a9f5f27fffdfd412bb597e666949cfa0f5cb4d329005824356fce789832554c355c3971631513a46d48bf01cef9872281fb3d8930b4487c7488b08",
-        "dest": "107_GGally.Rpkg"
+        "dest": "107_GGally.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/broom_0.7.5.tar.gz",
         "sha512": "07f24bafeb4d023e0005a9e9bb3b95f84a0c2153747c169cec2768737fc5510007c33baab833bb5b02c2620cbc3d6e16d9a13432057e8c1bbffe9ec280d983f9",
-        "dest": "108_broom.Rpkg"
+        "dest": "108_broom.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/mi_1.0.tar.gz",
         "sha512": "41295140031bfa478e56ae4abc529e1e499a4c7264c560d2a55142d7ca11057fc82d4e248a8317ca4777cf2dbeb55028fbfc25c9c758e82aefe5d7a0299d90c0",
-        "dest": "109_mi.Rpkg"
+        "dest": "109_mi.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/pbkrtest_0.5.1.tar.gz",
         "sha512": "b13cbcb3740be0a86510eb3ce933a54f6ef3fcf225f8203099c50de75c88b473a0367a5215aaf3c18566e07835d75dbd5a1be514ff5bed6e3c39293c50c6cce7",
-        "dest": "110_pbkrtest.Rpkg"
+        "dest": "110_pbkrtest.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/sem_3.1-11.tar.gz",
         "sha512": "adb2372a4a076085627b5bc0070e47d70080cb8ffbe1f2944ea76cb481db5e1200350aae0e8600924513e6353864dae25a10ca3f6e82e0db6bae38bf1feee64d",
-        "dest": "111_sem.Rpkg"
+        "dest": "111_sem.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/car_3.0-10.tar.gz",
         "sha512": "59e7f58e5f79c854402f15049ed1e36a8e62a1fd3279a3a27194619a61f8120826207290416695767672e7d962190c4a0676cb4f41edb8cf47e1e88fd78118e2",
-        "dest": "112_car.Rpkg"
+        "dest": "112_car.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/semPlot_1.1.2.tar.gz",
         "sha512": "ad44b5bf945b73c5302e845866e01daad1748a76d5f55507f25be476df12389de038ed23f369ffb7d4c33cfbad8659cf7491e61d1099e97125e3eac0b6229651",
-        "dest": "113_semPlot.Rpkg"
+        "dest": "113_semPlot.jmv.Rpkg"
     },
     {
         "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/afex_0.28-1.tar.gz",
         "sha512": "3de6df667259e883b00a328a12dc74430ff764c18250c2eec4cd6ae9042ce93a1054a68b905e9d34419d11cd76471bcbded4ff609711f6b5a6dcbbe67bdc735a",
-        "dest": "114_afex.Rpkg"
+        "dest": "114_afex.jmv.Rpkg"
     }
 ]

--- a/org.jamovi.jamovi.appdata.xml
+++ b/org.jamovi.jamovi.appdata.xml
@@ -36,6 +36,67 @@
   </screenshots>
 
   <releases>
+    <release version="2.0.2" date="2021-09-12">
+      <description>
+        <ul>
+          <li>Fix to stacked dot plot in descriptives</li>
+          <li>Fix to Q-Q plot in RM ANOVA</li>
+          <li>General bug-fixes and improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="2.0" date="2021-07-12">
+      <description>
+        <ul>
+          <li>Added the new variables tab</li>
+          <li>General bug-fixes and improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.4" date="2021-06-09">
+      <description>
+        <ul>
+          <li>General bug-fixes and improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.2" date="2021-05-17">
+      <description>
+        <ul>
+          <li>Fix to an interaction between output variables and filters</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.1" date="2021-04-19">
+      <description>
+        <ul>
+          <li>Descriptives - Added the option to transpose descriptives table</li>
+          <li>General improvements and bug-fixes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.0" date="2021-04-08">
+      <description>
+        <ul>
+          <li>AN(C)OVA - Added saving of residuals</li>
+          <li>Linear regression - Added saving of residuals, predicted values, cook's distance</li>
+          <li>PCA - Added saving component scores</li>
+          <li>Reliability - Added saving mean, sum scores</li>
+          <li>Descriptives - Added confidence intervals</li>
+          <li>scatr it now installed with jamovi by default</li>
+          <li>Bumped the version of R to 4.0.5 (modules will need to be reinstalled)</li>
+          <li>Bumped MRAN snapshot to 2021-04-01</li>
+          <li>General improvements and bug-fixes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.6.21" date="2021-03-23">
+      <description>
+        <ul>
+          <li>General improvements and bug-fixes</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.6.19" date="2021-03-22">
       <description>
         <ul>

--- a/org.jamovi.jamovi.appdata.xml
+++ b/org.jamovi.jamovi.appdata.xml
@@ -36,6 +36,58 @@
   </screenshots>
 
   <releases>
+    <release version="2.0" date="2021-07-12">
+      <description>
+        <ul>
+          <li>Added the new variables tab</li>
+          <li>General bug-fixes and improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.4" date="2021-06-09">
+      <description>
+        <ul>
+          <li>General bug-fixes and improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.2" date="2021-05-17">
+      <description>
+        <ul>
+          <li>Fix to an interaction between output variables and filters</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.1" date="2021-04-19">
+      <description>
+        <ul>
+          <li>Descriptives - Added the option to transpose descriptives table</li>
+          <li>General improvements and bug-fixes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8.0" date="2021-04-08">
+      <description>
+        <ul>
+          <li>AN(C)OVA - Added saving of residuals</li>
+          <li>Linear regression - Added saving of residuals, predicted values, cook's distance</li>
+          <li>PCA - Added saving component scores</li>
+          <li>Reliability - Added saving mean, sum scores</li>
+          <li>Descriptives - Added confidence intervals</li>
+          <li>scatr it now installed with jamovi by default</li>
+          <li>Bumped the version of R to 4.0.5 (modules will need to be reinstalled)</li>
+          <li>Bumped MRAN snapshot to 2021-04-01</li>
+          <li>General improvements and bug-fixes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.6.21" date="2021-03-23">
+      <description>
+        <ul>
+          <li>General improvements and bug-fixes</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.6.19" date="2021-03-22">
       <description>
         <ul>

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -240,8 +240,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/cf/8d/6345b4f32b37945fedc1e027e83970005fc9c699068d2f566b82826515f2/numpy-1.16.2.zip",
-                    "sha512": "5edd460c0948f424d8deb72f44a33db8ac6a973859b25c824533330dccb4f844197a437e945cd382760bbb6983fd120b08c949ac437973a915246024a8ebc911"
+                    "url": "https://files.pythonhosted.org/packages/82/a8/1e0f86ae3f13f7ce260e9f782764c16559917f24382c74edfb52149897de/numpy-1.20.2.zip",
+                    "sha512": "337a66d68c965da06f757a89b58d30b83ec0b2f3c7a3bb39496e5031e50fee6c4f2ec090202c3da9a20613864ea46d032ae75af1de5c33eebe515133ef37d40c"
                 }
             ]
         },
@@ -263,8 +263,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/a9/b4/5598a706697d1e2929eaf7fe68898ef4bea76e4950b9efbe1ef396b8813a/scipy-1.2.1.tar.gz",
-                    "sha512": "80caf9af93046c0d58829a61eb90d824aabe8a53f3e7d8a72efc44accaa3299d1e22adbb4852ed192cee6e47aafbb4ebea3115233ed11f1ef05dd373866b0243"
+                    "url": "https://github.com/scipy/scipy/releases/download/v1.6.2/scipy-1.6.2.tar.xz",
+                    "sha512": "2253f257d5c55739a47759e039602dc542bd1a068c5883fd2a80a60bc7d3e8372d467d589ae2c83b9a847d0fb76c1fb841208213297db284f142fac98dd33b8e"
                 }
             ]
         },

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -177,35 +177,6 @@
             ]
         },
         {
-            "name": "cpython",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz",
-                    "sha512": "ca37ad0e7c5845f5f228566aa8ff654a8f428c7d4a5aaabff29baebb0ca3219b31ba8bb2607f89e37cf3fc564f023b8407e53a4f2c47bd99122c1cc222613e37"
-                }
-            ],
-            "cleanup": [
-                "/bin/2to3",
-                "/bin/2to3-3.8",
-                "/bin/easy_install-3.8",
-                "/bin/f2py3",
-                "/bin/f2py3.8",
-                "/bin/idle3",
-                "/bin/idle3.8",
-                "/bin/pip3",
-                "/bin/pip3.8",
-                "/bin/pydoc3",
-                "/bin/pydoc3.8",
-                "/bin/python3-config",
-                "/bin/python3.8-config",
-                "/bin/python3.8m",
-                "/bin/python3.8m-config",
-                "/bin/pyvenv",
-                "/bin/pyvenv-3.8"
-            ]
-        },
-        {
             "name": "xslt-config",
             "buildsystem": "simple",
             "build-commands": [

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -480,7 +480,7 @@
             "name": "env.conf",
             "buildsystem": "simple",
             "build-commands": [
-                "sed -E -e \"s|JAMOVI_SERVER_CMD=[A-Za-z0-9_/]+|JAMOVI_SERVER_CMD=/app/bin/python3|g\" -e \"s|R_HOME=.*|R_HOME=$R_HOME|g\" -e \"s|R_LIBS=.*|R_LIBS=$R_HOME/library|g\" env.conf > /app/bin/env.conf"
+                "sed -E -e \"s|R_HOME=.*|R_HOME=$R_HOME|g\" -e \"s|R_LIBS=.*|R_LIBS=$R_HOME/library|g\" env.conf > /app/bin/env.conf"
             ],
             "sources":[
                 {

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -128,7 +128,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://mirror.freedif.org/GNU/gsl/gsl-2.6.tar.gz",
+                    "url": "https://ftp.gnu.org/gnu/gsl/gsl-2.6.tar.gz",
                     "sha512": "0be8240715f0b86aba2c63d9f12da4dba4719d4e350e9308d279e0dd3b2f0519ea26fd2e38a17f3e8cf43aacbaa2455207a7ca0d6c305f3b8725e8ece2250a74"
                 }
             ]

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.jamovi.jamovi",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "20.08",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "19.08",
+    "base-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "jamovi",
     "separate-locales": false,

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -522,20 +522,25 @@
             "name": "jmv",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p /app/lib/jamovi/modules",
-                "mkdir -p jmv/build/R4.0.5-linux",
-                "/app/bin/R CMD INSTALL *.Rpkg --library=jmv/build/R4.0.5-linux --no-docs --no-html --no-data --no-help --no-demo --no-multiarch",
                 "cd jamovi-compiler && npm install --offline",
-                "./jamovi-compiler.sh --install jmv --to /app/lib/jamovi/modules --home /app --patch-version --skip-remotes"
+                "mkdir -p /app/lib/jamovi/modules",
+                "mkdir -p   jmv/build/R4.0.5-linux",
+                "/app/bin/R CMD INSTALL *.jmv.Rpkg --library=jmv/build/R4.0.5-linux   --no-docs --no-html --no-data --no-help --no-demo --no-multiarch",
+                "./jamovi-compiler.sh --install jmv --to /app/lib/jamovi/modules --home /app --patch-version --skip-remotes",
+                "mkdir -p scatr/build/R4.0.5-linux",
+                "/app/bin/R CMD INSTALL *.scatr.Rpkg --library=scatr/build/R4.0.5-linux --no-docs --no-html --no-data --no-help --no-demo --no-multiarch",
+                "./jamovi-compiler.sh --install scatr --to /app/lib/jamovi/modules --home /app --rlibs /app/lib/jamovi/modules/jmv/R"
             ],
             "build-options": {
                 "env": {
-                    "npm_config_cache": "../npm-cache"
+                    "npm_config_cache": "../npm-cache",
+                    "R_LIBS": "/app/lib/jamovi/modules/jmv/R"
                 }
             },
             "sources": [
                 "jmc-deps-sources.json",
                 "jmv-deps-sources.json",
+                "scatr-deps-sources.json",
                 "jamovi-source.json",
                 {
                     "type": "script",

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -54,8 +54,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.bz2",
-                    "sha256": "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9"
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2",
+                    "sha512": "5d68bed98c57e03b4cb2420d9b856e5f0669561a6142a4b0c9c8a58dc5b6b28e16ccbb16ac559c3a3198c45769a246bf996b96cb7b6a019dd15f05c2270e9429"
                 }
             ],
             "cleanup": [

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -97,8 +97,8 @@
             "sources": [
                 {
                     "type":"archive",
-                    "url": "https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz",
-                    "sha512":"b7330613ee9795f54cde3dd9f7509be83d9156fb8577c17179727ee01450db27704249f68bd48e0331e2df09c2d9833d8bb019c4f9ce9ba669df74650ff2e842"
+                    "url": "https://cran.r-project.org/src/base/R-4/R-4.0.5.tar.gz",
+                    "sha512":"6ff5b0f9cb6b17f66cde1f5585d1b33659dbae8919d34c2e593f68a0bff4d0425aa9704d99284d103702a9cd42f613311f3a87af6b939b1af65dcec80bf2ca8c"
                 }
             ],
             "cleanup": [
@@ -523,8 +523,8 @@
             "buildsystem": "simple",
             "build-commands": [
                 "mkdir -p /app/lib/jamovi/modules",
-                "mkdir -p jmv/build/R4.0.2-linux",
-                "/app/bin/R CMD INSTALL *.Rpkg --library=jmv/build/R4.0.2-linux --no-docs --no-html --no-data --no-help --no-demo --no-multiarch",
+                "mkdir -p jmv/build/R4.0.5-linux",
+                "/app/bin/R CMD INSTALL *.Rpkg --library=jmv/build/R4.0.5-linux --no-docs --no-html --no-data --no-help --no-demo --no-multiarch",
                 "cd jamovi-compiler && npm install --offline",
                 "./jamovi-compiler.sh --install jmv --to /app/lib/jamovi/modules --home /app --patch-version --skip-remotes"
             ],

--- a/python-deps.json
+++ b/python-deps.json
@@ -1,14 +1,19 @@
 {
-    "name": "python3-deps",
+    "name": "python3-cython",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
+        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
     ],
     "sources": [
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz",
             "sha512": "359c45d843fd839797572efeab121f17b1947647960dfb062f3618f25f71e1a6bc4bab14a1720b6b67f256089d5d48c452ec5419e3130222765c7ca41db11dad"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz",
+            "sha512": "6216e63996e83b887cdcee6cd912d42e7da853640336b9190f5115d687848a902ee5a8edd6bfaef645c066b89e17dcd80ca1387688eb80a527ec23a0a4636e8f"
         },
         {
             "type": "file",

--- a/python-deps.json
+++ b/python-deps.json
@@ -2,7 +2,7 @@
     "name": "python3-cython",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp pybind11 setuptools wheel pip"
     ],
     "sources": [
         {
@@ -12,8 +12,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz",
-            "sha512": "6216e63996e83b887cdcee6cd912d42e7da853640336b9190f5115d687848a902ee5a8edd6bfaef645c066b89e17dcd80ca1387688eb80a527ec23a0a4636e8f"
+            "url": "https://files.pythonhosted.org/packages/d3/38/adc49a5aca4f644e6322237089fdcf194084f5fe41445e6e632f28b32bf7/Cython-0.29.22.tar.gz",
+            "sha512": "721812b7009049717d907f3b22cc63a28b882a843d3af613ddd5a47a6588fb49ffd4188856ed4a2612f8abe07d35ba29b2143b8ff6d184a99c22328db09e9c27"
         },
         {
             "type": "file",
@@ -29,6 +29,11 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/97/e7/af7219a0fe240e8ef6bb555341a63c43045c21ab0392b4435e754b716fa1/yarl-1.6.3.tar.gz",
             "sha512": "4c76b94198b8e334f4b4e71d92b0fe23f752d35e0c29bc68df99648b3f48fbb6e3dd8d7339138544e5dc8fbf64c15cb61678052670ac47edc5be958df819d42e"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/46/0e/3131a9ae6e6cd1d718cfdd3e2c25f681f2db29be30763aa54b9310de5fea/pybind11-2.6.2.tar.gz",
+            "sha512": "8b76250817ced714445982f936f801b33a9184664f1f9a43ac18c81116361581a0475eda228620c3f3a3f9bd2c681aaa41e8dea0139039c6164332481937d3cb"
         },
         {
             "type": "file",

--- a/python-deps.json
+++ b/python-deps.json
@@ -7,58 +7,48 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/cb/19/57503b5de719ee45e83472f339f617b0c01ad75cba44aba1e4c97c2b0abd/idna-2.9.tar.gz",
-            "sha512": "2bd3fdae46fe7045640912872b0a3955de3abce62fd222b16ea2c997a04755acc834eeb645e5610d621c176d4b963e1d4a71228fba14efad54999cdf3c02eaf4"
+            "url": "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz",
+            "sha512": "359c45d843fd839797572efeab121f17b1947647960dfb062f3618f25f71e1a6bc4bab14a1720b6b67f256089d5d48c452ec5419e3130222765c7ca41db11dad"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/39/2b/0a66d5436f237aff76b91e68b4d8c041d145ad0a2cdeefe2c42f76ba2857/lxml-4.5.0.tar.gz",
-            "sha512": "7cb957b2ab9931c32984ad0808f51e650e82e2d9b14df3fd8df2dd8f2c5c261d26ebf2c672b723e89b00b867a0a8dbb9130023e48a5f302fd02d5409e1c8cd6c"
+            "url": "https://files.pythonhosted.org/packages/d3/38/adc49a5aca4f644e6322237089fdcf194084f5fe41445e6e632f28b32bf7/Cython-0.29.22.tar.gz",
+            "sha512": "721812b7009049717d907f3b22cc63a28b882a843d3af613ddd5a47a6588fb49ffd4188856ed4a2612f8abe07d35ba29b2143b8ff6d184a99c22328db09e9c27"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/6a/28/d32852f2af6b5ead85d396249d5bdf450833f3a69896d76eb480d9c5e406/typing_extensions-3.7.4.2.tar.gz",
-            "sha512": "7a74c4a97d8cda3e56830c92b409235ffbe7cf0c1685b7fefa7a275a0abf21937622d12c25b4163b4927f6269ed689cbd30f95990ad0b7d2d4341ed648516819"
+            "url": "https://files.pythonhosted.org/packages/ed/46/e298a50dde405e1c202e316fa6a3015ff9288423661d7ea5e8f22f589071/wheel-0.36.2.tar.gz",
+            "sha512": "73f5c6e77b8c396163b02e12ce7291e32960d771c732d8e97476971201b29e654d53551b2ce17db1fbde5697ced1908607995cac38fe2b61c63aec6abd4b6aaf"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz",
-            "sha512": "87372877d396bd06cdb6b9052ef8822ef0589a211659bf27d7a1c4deca8429cb39e120a23e5d590d7adc0f8059ce1c8af42409bebd7c6d504d49dc8504d5683a"
+            "url": "https://files.pythonhosted.org/packages/f1/7d/fb475cd963bd9d244f95a90c98f518f5c834fefe749f25f9f479ca2d8a51/openpyxl-3.0.7.tar.gz",
+            "sha512": "00a6bd824d57236456300dc5ccf82d44a57af52302e8298a7c407142dd7a67fc535f85c6870393e97fc4029f010722cad3f3c30db666d8aab748b1139d06f77b"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/95/8c/83563c60489954e5b80f9e2596b93a68e1ac4e4a730deb1aae632066d704/openpyxl-3.0.3.tar.gz",
-            "sha512": "f0cd3fb217338124ca046a5f3b7eb2f8bbd933b328dc5c00d687e1d9b1ebd6c6a0668a1ff9a842cb2bbc32ce8654cc992f013d02ec24a3da39903e3e4f956942"
+            "url": "https://files.pythonhosted.org/packages/97/e7/af7219a0fe240e8ef6bb555341a63c43045c21ab0392b4435e754b716fa1/yarl-1.6.3.tar.gz",
+            "sha512": "4c76b94198b8e334f4b4e71d92b0fe23f752d35e0c29bc68df99648b3f48fbb6e3dd8d7339138544e5dc8fbf64c15cb61678052670ac47edc5be958df819d42e"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/8e/76/66066b7bc71817238924c7e4b448abdb17eb0c92d645769c223f9ace478f/pip-20.0.2.tar.gz",
-            "sha512": "72f9c4b8a5a3c5f8074bc2b671a118942f161fb145c38077ded8a18f07537eb674c679fdcf7c3f3f0aeee11d66fe34eaa157f53f1f689fce3e12567e5339ac89"
+            "url": "https://files.pythonhosted.org/packages/9f/24/1444ee2c9aee531783c031072a273182109c6800320868ab87675d147a05/idna-3.1.tar.gz",
+            "sha512": "23c02520d00a99855d552a9b9def529f0baeec7d27e8036c544dd654ade15243fd5c9e5ad02e73b83a9ca3bb335ab2584233d17345a6a5e6d5ac089e8ac81e8a"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/49/8a/6a4135469372da2e3d9f88f71c6d00d8a07ef65f121eeca0c7ae21697219/Cython-0.29.16.tar.gz",
-            "sha512": "bbfd917a37a58389eff6780634ed3d58c6bfc69278d4d7a9b82d44f3a69a798961ac017dfc2a1a2b5db930bf73f1b5bf2e5ae0fde1c079012d1aa36886181e32"
+            "url": "https://files.pythonhosted.org/packages/b7/2d/ad02de84a4c9fd3b1958dc9fb72764de1aa2605a9d7e943837be6ad82337/pip-21.0.1.tar.gz",
+            "sha512": "b80387fed6abf64cb4794686a82a415cf58b4516b9db17a5db496152b432b81bc638d8de91d40578f6dac08e26c0d0d4099901b9a186d73cf36691f24c4b4ee9"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/95/84/119a46d494f008969bf0c775cb2c6b3579d3c4cc1bb1b41a022aa93ee242/tornado-6.0.4.tar.gz",
-            "sha512": "d29d69cf40f8b34fb2c55d81b6ecd9bc7c6fdf644eb4ff35452829510c0d5ec185da0a6067fec3e8afb2bedf9f5f08b06adb0ad53dcab04cb791a75abc304d6e"
+            "url": "https://files.pythonhosted.org/packages/b0/e1/3bf55eb999735a948ea4d8c417458ba2c14615c104fff8976729832efb8f/protobuf-3.15.7.tar.gz",
+            "sha512": "440009d4d4942091a5e759ab4fcd3b27ea231d504186041106bf41c6f5ef5dffb6ba5d45aab2c61ec6f45b77bb789bacfcabf1ad049f0ffb1f33970fe5575d94"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/a6/8d/aba802912a3ffbaf6c3ae7f3208206f0811b72e48adff86edd0f933bb9d7/pyexcel-ezodf-0.3.4.tar.gz",
-            "sha512": "019584191acdbf6acb50d61fcc720d9945c47722156a0d3a5882d4e2e169f79b21d9fed2a2e00c4447bb4691b82559bb5440dd37814c42c32d4edb3ff2430367"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d6/67/6e2507586eb1cfa6d55540845b0cd05b4b77c414f6bca8b00b45483b976e/yarl-1.4.2.tar.gz",
-            "sha512": "036562b645d7b9b3ed4a749decb189587b41ab13b5dda5ff461b00eebadf1ecdbd8d5ae06932cc7d8b7ff551cd630f8671eb0f6c854b20996cda4a6897994fa0"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/61/b4/475114b3f1671da634f89239e61038f8742d9ac13aa34b32a05bf8022d22/multidict-4.7.5.tar.gz",
-            "sha512": "cde917bee0466ab6af9ee08835c41ba2156483855510a054b79894ebd5fc89549de04284e3eef5c2123297db219c326f43a3587bc15aa51857fda122f087e42e"
+            "url": "https://files.pythonhosted.org/packages/1c/74/e8b46156f37ca56d10d895d4e8595aa2b344cff3c1fb3629ec97a8656ccb/multidict-5.1.0.tar.gz",
+            "sha512": "2a6a6aaedb6ed6f7c2b9d2a848623a6a1b5908de346d2b6c8a7b3d207e3c4cf2b7fe4a29536a1939ebbee6905aabcd23c07f818f55cc16e9362a04455d440253"
         },
         {
             "type": "file",
@@ -67,28 +57,13 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz",
-            "sha512": "4dea0f4e7961e8b582d665501c65852dc3b73516a0b6f78b0888c8670f1450df58bd3eea418777f41080b842ab6c3d8633be1034bcf920192e5590d5316e2c9e"
+            "url": "https://files.pythonhosted.org/packages/e5/21/a2e4517e3d216f0051687eea3d3317557bde68736f038a3b105ac3809247/lxml-4.6.3.tar.gz",
+            "sha512": "57489c42257afd00376886d6873c97088778afa8009fa644e2660722d134f346030218c24be6329ee828f73f5164cdd1dad583c17addbdf3e0c84e4d8ab9e176"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/b5/96/af1686ea8c1e503f4a81223d4a3410e7587fd52df03083de24161d0df7d4/setuptools-46.1.3.zip",
-            "sha512": "7f8f99313ce2af2cbfa86ff9a3135bc3445804e9323a375b498d20dad7f8fc819481da0c2a057160397e98b6178c1eb453a093652cfdfe7896c9d31732f7ad8c"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/46/03/07c4894aae38b0de52b52586b24bf189bb83e4ddabfe2e2c8f2419eec6f4/idna-ssl-1.1.0.tar.gz",
-            "sha512": "f9db74cecabbbfddfd1817bbd8434ef2aafeea433c3eefff3f94c7e994da40e3f315fcda527f3a0c3743028f26bbc934f1dd21f94134123c3271975d0527cd35"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/c9/d5/e6e789e50e478463a84bd1cdb45aa408d49a2e1aaffc45da43d10722c007/protobuf-3.11.3.tar.gz",
-            "sha512": "1e9e0d03715e8d3f5271c58139000cb512ab4cd586bfdd5ce42ff7a5971fa427285fd4ec51894a63b0435facb200088c5220677e2dd645aab6821c90476ff13c"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/00/94/f9fa18e8d7124d7850a5715a0b9c0584f7b9375d331d35e157cee50f27cc/aiohttp-3.6.2.tar.gz",
-            "sha512": "49bd3089158c05ff6312420190ccd7fed95efb4a18b8aff7497d5507c71c692080d6949801edabdcd95379ca8e6614398408118d72ff1e782399e059e2cfc1a8"
+            "url": "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz",
+            "sha512": "ebd7f420e1094445270db993f6373ffe7370419e002b0bb13299dc6c9b0f7c4e77b0f44f871fba6371e6869e7c86728514367db377e3137487a3acf50cb81e96"
         },
         {
             "type": "file",
@@ -97,28 +72,43 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/98/c3/2c227e66b5e896e15ccdae2e00bbc69aa46e9a8ce8869cc5fa96310bf612/attrs-19.3.0.tar.gz",
-            "sha512": "b5b641e6732156d1454ed6c49e3a6b29200a8d3f1515fb59aeb85fcb5e9ab6a1d760904de45083cae5250e7bf1a7aa2c1f3ede217240a63f989ae4bb484f2511"
+            "url": "https://files.pythonhosted.org/packages/f0/cb/80a4a274df7da7b8baf083249b0890a0579374c3d74b5ac0ee9291f912dc/attrs-20.3.0.tar.gz",
+            "sha512": "640532c6b763fd96572e5d85e93c111bebc4c5e0ff9419fe92fb51280f03acb5f9f43339f57d30659e777d5578460675c60ec0a362f9ad433893e3624ce6a931"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/7b/b0/fa20fce23e9c3b55b640e629cb5edf32a85e6af3cf7af599940eb0c753fe/jdcal-1.4.1.tar.gz",
-            "sha512": "5e14f470f35764c0d76fcf0ee13f9ea0879e645b589a48636207b7848f3df0437343898595c8cf19b8e4fe8a172d4e82aa06e56284ed263154c93de217e24e39"
+            "url": "https://files.pythonhosted.org/packages/16/06/0f7367eafb692f73158e5c5cbca1aec798cdf78be5167f6415dd4205fa32/typing_extensions-3.7.4.3.tar.gz",
+            "sha512": "fa1f96b73b13308ddb2676684862916aac8741be4523387c6a0f682a52d307190aac3e4149317842e686d14483d8a37a9e1de2514a2d1ca86f9ae9c8b0e18eb1"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz",
-            "sha512": "61a03b23447a2bfe52ceed4dd1b9afdb5784da1933a623776883ee9f297e341f633e27f0ce0230bd5fdc5fdb5382105ab42736a74a417ddeb9f83af57455dba5"
+            "url": "https://files.pythonhosted.org/packages/99/f5/90ede947a3ce2d6de1614799f5fea4e93c19b6520a59dc5d2f64123b032f/aiohttp-3.7.4.post0.tar.gz",
+            "sha512": "1697390a8f40a1de0335343f7c3451a1b772e181364edd30c5834abf5e8f3020bdf3fa4226d435e4c2b73340bea567188089d67a1fc93826e1a51bc5e419f0d7"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a6/8d/aba802912a3ffbaf6c3ae7f3208206f0811b72e48adff86edd0f933bb9d7/pyexcel-ezodf-0.3.4.tar.gz",
+            "sha512": "019584191acdbf6acb50d61fcc720d9945c47722156a0d3a5882d4e2e169f79b21d9fed2a2e00c4447bb4691b82559bb5440dd37814c42c32d4edb3ff2430367"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz",
+            "sha512": "eb840ac17f433f1fc4af56de75cfbfe0b54e6a737bb23c453bf09a4a13d768d153e46064880dc763f4c5cc2785b78ea6d3d3b4a41fed181cb9064837e3f699a9"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/94/75/05e1d69c61c4dfaf65ad12785cd18bedc1e0129976c55914d6aea59c7da8/setuptools-54.2.0.tar.gz",
+            "sha512": "b18cd075cf59b8648611eef1874de41199ede6ffe6d7f5047586c6ac8783fe18b9a4f537783e590e7aec127033f612b93925e92f039bd6416a609fcfb262e354"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/cf/44/cc9590db23758ee7906d40cacff06c02a21c2a6166602e095a56cbf2f6f6/tornado-6.1.tar.gz",
+            "sha512": "0ec1db1fad911182bda547c177a18b107b906cf66576443069e2b986cf041b3d4ebe08e5a168aa5cd3b56547f32f8b384bacaf74db89f582951d7b610b7494e8"
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/0b/b1/3037e0e380d5fab2824e69a59bd374da402c0cef264ccb3fe5d71c230c4b/nanomsg-1.0.tar.gz",
             "sha512": "2d1e6349b73481aaa9fb0a683f531f7fe92374e1893fe236763ec86c6389ad1a3ce3900b1e1b4dff165c90447f2516a5b9aff0e1760dc190fa093c3cc2c301aa"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/75/28/521c6dc7fef23a68368efefdcd682f5b3d1d58c2b90b06dc1d0b805b51ae/wheel-0.34.2.tar.gz",
-            "sha512": "7f2143b26812f94330671ab5d2bbc31f0a4fc103dbc8d7b971afd5e5ca7e72140cb61fa264a39ec8e80bae61ebb22c738bfbb803242b52a32eee6a3e90aa1513"
         }
     ]
 }

--- a/python-deps.json
+++ b/python-deps.json
@@ -1,19 +1,14 @@
 {
-    "name": "python3-cython",
+    "name": "python3-deps",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
+        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
     ],
     "sources": [
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz",
             "sha512": "359c45d843fd839797572efeab121f17b1947647960dfb062f3618f25f71e1a6bc4bab14a1720b6b67f256089d5d48c452ec5419e3130222765c7ca41db11dad"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d3/38/adc49a5aca4f644e6322237089fdcf194084f5fe41445e6e632f28b32bf7/Cython-0.29.22.tar.gz",
-            "sha512": "721812b7009049717d907f3b22cc63a28b882a843d3af613ddd5a47a6588fb49ffd4188856ed4a2612f8abe07d35ba29b2143b8ff6d184a99c22328db09e9c27"
         },
         {
             "type": "file",

--- a/python-deps.json
+++ b/python-deps.json
@@ -2,7 +2,7 @@
     "name": "python3-cython",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
+        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp"
     ],
     "sources": [
         {
@@ -14,11 +14,6 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz",
             "sha512": "6216e63996e83b887cdcee6cd912d42e7da853640336b9190f5115d687848a902ee5a8edd6bfaef645c066b89e17dcd80ca1387688eb80a527ec23a0a4636e8f"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ed/46/e298a50dde405e1c202e316fa6a3015ff9288423661d7ea5e8f22f589071/wheel-0.36.2.tar.gz",
-            "sha512": "73f5c6e77b8c396163b02e12ce7291e32960d771c732d8e97476971201b29e654d53551b2ce17db1fbde5697ced1908607995cac38fe2b61c63aec6abd4b6aaf"
         },
         {
             "type": "file",
@@ -34,11 +29,6 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/9f/24/1444ee2c9aee531783c031072a273182109c6800320868ab87675d147a05/idna-3.1.tar.gz",
             "sha512": "23c02520d00a99855d552a9b9def529f0baeec7d27e8036c544dd654ade15243fd5c9e5ad02e73b83a9ca3bb335ab2584233d17345a6a5e6d5ac089e8ac81e8a"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/b7/2d/ad02de84a4c9fd3b1958dc9fb72764de1aa2605a9d7e943837be6ad82337/pip-21.0.1.tar.gz",
-            "sha512": "b80387fed6abf64cb4794686a82a415cf58b4516b9db17a5db496152b432b81bc638d8de91d40578f6dac08e26c0d0d4099901b9a186d73cf36691f24c4b4ee9"
         },
         {
             "type": "file",
@@ -94,11 +84,6 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz",
             "sha512": "eb840ac17f433f1fc4af56de75cfbfe0b54e6a737bb23c453bf09a4a13d768d153e46064880dc763f4c5cc2785b78ea6d3d3b4a41fed181cb9064837e3f699a9"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/94/75/05e1d69c61c4dfaf65ad12785cd18bedc1e0129976c55914d6aea59c7da8/setuptools-54.2.0.tar.gz",
-            "sha512": "b18cd075cf59b8648611eef1874de41199ede6ffe6d7f5047586c6ac8783fe18b9a4f537783e590e7aec127033f612b93925e92f039bd6416a609fcfb262e354"
         },
         {
             "type": "file",

--- a/python-deps.json
+++ b/python-deps.json
@@ -2,7 +2,7 @@
     "name": "python3-cython",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install -U --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp"
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp setuptools wheel pip"
     ],
     "sources": [
         {
@@ -14,6 +14,11 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz",
             "sha512": "6216e63996e83b887cdcee6cd912d42e7da853640336b9190f5115d687848a902ee5a8edd6bfaef645c066b89e17dcd80ca1387688eb80a527ec23a0a4636e8f"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/ed/46/e298a50dde405e1c202e316fa6a3015ff9288423661d7ea5e8f22f589071/wheel-0.36.2.tar.gz",
+            "sha512": "73f5c6e77b8c396163b02e12ce7291e32960d771c732d8e97476971201b29e654d53551b2ce17db1fbde5697ced1908607995cac38fe2b61c63aec6abd4b6aaf"
         },
         {
             "type": "file",
@@ -29,6 +34,11 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/9f/24/1444ee2c9aee531783c031072a273182109c6800320868ab87675d147a05/idna-3.1.tar.gz",
             "sha512": "23c02520d00a99855d552a9b9def529f0baeec7d27e8036c544dd654ade15243fd5c9e5ad02e73b83a9ca3bb335ab2584233d17345a6a5e6d5ac089e8ac81e8a"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b7/2d/ad02de84a4c9fd3b1958dc9fb72764de1aa2605a9d7e943837be6ad82337/pip-21.0.1.tar.gz",
+            "sha512": "b80387fed6abf64cb4794686a82a415cf58b4516b9db17a5db496152b432b81bc638d8de91d40578f6dac08e26c0d0d4099901b9a186d73cf36691f24c4b4ee9"
         },
         {
             "type": "file",
@@ -84,6 +94,11 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz",
             "sha512": "eb840ac17f433f1fc4af56de75cfbfe0b54e6a737bb23c453bf09a4a13d768d153e46064880dc763f4c5cc2785b78ea6d3d3b4a41fed181cb9064837e3f699a9"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/94/75/05e1d69c61c4dfaf65ad12785cd18bedc1e0129976c55914d6aea59c7da8/setuptools-54.2.0.tar.gz",
+            "sha512": "b18cd075cf59b8648611eef1874de41199ede6ffe6d7f5047586c6ac8783fe18b9a4f537783e590e7aec127033f612b93925e92f039bd6416a609fcfb262e354"
         },
         {
             "type": "file",

--- a/scatr-deps-sources.json
+++ b/scatr-deps-sources.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/lazyeval_0.2.2.tar.gz",
+        "sha512": "b1115386f76b14e9e718ff2234de1dcdd8d11f2f06b9490e901c0496a0780f96d543c6ccd6552791f1e004e379cdeeccec7c9075db9def639664bd9370ea889e",
+        "dest": "000_lazyeval.scatr.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/cowplot_1.1.1.tar.gz",
+        "sha512": "474be04bb4e828c67642aa62e5eb35640bfdf49da2411d94cb0f4f32098db18eebe026e8aa2b590d467f08bb2bcdbd809bf97a7cdc1d975a64632eb0fb90bd6b",
+        "dest": "001_cowplot.scatr.Rpkg"
+    },
+    {
+        "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ggstance_0.3.5.tar.gz",
+        "sha512": "601515951bb7fdaa0b9c74d0f3310d330e9445f7086ca03935db6de375c3d411ff9365d1d036b7580d24c9f5d51509e4165f456bde7253749c09b831fe85df7e",
+        "dest": "002_ggstance.scatr.Rpkg"
+    }
+]

--- a/scatr-deps-sources.json
+++ b/scatr-deps-sources.json
@@ -13,8 +13,14 @@
     },
     {
         "type": "archive",
+        "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/plyr_1.8.6.tar.gz",
+        "sha512": "2c41e77b338055fbc500cf3c5e1f8b0e8339692eb18b63edceca92f4e4ba4b3930d718b59da79ab459230f4177de718a034069bbf42c1b0e47b97ba99dcacec7",
+        "dest": "002_plyr.scatr.Rpkg"
+    },
+    {
+        "type": "archive",
         "url": "https://cran.microsoft.com/snapshot/2021-04-01/src/contrib/ggstance_0.3.5.tar.gz",
         "sha512": "601515951bb7fdaa0b9c74d0f3310d330e9445f7086ca03935db6de375c3d411ff9365d1d036b7580d24c9f5d51509e4165f456bde7253749c09b831fe85df7e",
-        "dest": "002_ggstance.scatr.Rpkg"
+        "dest": "003_ggstance.scatr.Rpkg"
     }
 ]


### PR DESCRIPTION
I tried out building and running it, and it is working without any issues on my machine. If you tell me what you did to cause the segfaults, I can do some specific testing too.
I did the following steps relative to the state of your repo:
```
git clone https://github.com/jonathon-love/org.jamovi.jamovi.git flatpak
cd flatpak
git checkout 2008-runtime 
# changing origin to my repo and adding the flathub-repo for getting the most recent state
git remote remove origin 
git remote add origin git@github.com:sjentsch/org.jamovi.jamovi.git
git remote add jonathon-love https://github.com/jonathon-love/org.jamovi.jamovi
git remote add flathub https://github.com/flathub/org.jamovi.jamovi.git
git push --set-upstream origin 2008-runtime
git pull 
git merge flathub/master
# merge needed manual edits on the following three files
gedit org.jamovi.jamovi.json jmv-deps-sources.json jamovi-source.json 
git add jamovi-source.json 
git add org.jamovi.jamovi.json 
git add jmv-deps-sources.json 
git commit -a -m "Merge 2008-runtime with curren master (flathub)"
git submodule update --init 
git submodule update --remote --merge shared-modules 
git commit -a -m "Merge 2008-runtime with curren master (flathub)"
# in org.jamovi.jamovi.appdata.xml, I further did some update of the version history
gedit org.jamovi.jamovi.appdata.xml 
git commit -a -m "Update version history and version number"
# finally, I had to manually add plyr (R package) in scatr-deps-sources.json
gedit scatr-deps-sources.json
# likely, you already have the ncessary SDKs installed and don't need the following two lines
flatpak install flathub org.freedesktop.Platform//20.08 org.freedesktop.Sdk//20.08
flatpak install flathub org.electronjs.Electron2.BaseApp/x86_64/20.08

# build and install
flatpak-builder --user --install build-dir org.jamovi.jamovi.json --force-clean

# run - likely, you will have to uninstall the version from flatpak before run
# flatpak uninstall org.jamovi.jamovi
flatpak run org.jamovi.jamovi
```